### PR TITLE
fix: Vercel config for Next.js (avoid 404)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
-  "buildCommand": "pnpm build",
-  "outputDirectory": ".next",
-  "installCommand": "pnpm install"
+  "framework": "nextjs",
+  "installCommand": "pnpm install",
+  "buildCommand": "pnpm build"
 }


### PR DESCRIPTION
Removes static outputDirectory override and sets framework=nextjs so Vercel treats this as a Next.js project.\n\nValidation: pnpm build