### PR TITLE
feat: add experiment favorites (feature-003)

### DIFF
--- a/app/experiments/page.tsx
+++ b/app/experiments/page.tsx
@@ -1,7 +1,18 @@
+'use client'
+
 import Link from "next/link";
+import { useState } from "react";
 import { experiments } from "../../experiments/index";
+import { useFavorites } from "../../hooks/useFavorites";
 
 export default function ExperimentsPage() {
+  const { favorites, toggleFavorite, isFavorite } = useFavorites();
+  const [filter, setFilter] = useState<'all' | 'favorites'>('all');
+
+  const filteredExperiments = filter === 'favorites' 
+    ? experiments.filter(exp => isFavorite(exp.id))
+    : experiments;
+
   return (
     <main className="min-h-screen p-8">
       <div className="max-w-4xl mx-auto">
@@ -15,19 +26,65 @@ export default function ExperimentsPage() {
         </nav>
 
         <h1 className="text-4xl font-bold mb-2">Experiments</h1>
-        <p className="text-gray-600 dark:text-gray-400 mb-8">
+        <p className="text-gray-600 dark:text-gray-400 mb-6">
           Explore our collection of product experiments
         </p>
 
+        {/* Filter Tabs */}
+        <div className="flex gap-2 mb-8">
+          <button
+            onClick={() => setFilter('all')}
+            className={`px-4 py-2 rounded-lg font-medium transition-colors ${
+              filter === 'all'
+                ? 'bg-blue-600 text-white'
+                : 'bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-300 dark:hover:bg-gray-600'
+            }`}
+          >
+            All ({experiments.length})
+          </button>
+          <button
+            onClick={() => setFilter('favorites')}
+            className={`px-4 py-2 rounded-lg font-medium transition-colors flex items-center gap-2 ${
+              filter === 'favorites'
+                ? 'bg-yellow-500 text-white'
+                : 'bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-300 dark:hover:bg-gray-600'
+            }`}
+          >
+            ⭐ Favorites ({favorites.length})
+          </button>
+        </div>
+
+        {/* Empty State for Favorites */}
+        {filter === 'favorites' && favorites.length === 0 && (
+          <div className="text-center py-16 bg-gray-50 dark:bg-gray-800/50 rounded-lg">
+            <p className="text-4xl mb-4">⭐</p>
+            <h3 className="text-xl font-semibold text-gray-700 dark:text-gray-300 mb-2">
+              No favorites yet
+            </h3>
+            <p className="text-gray-500 dark:text-gray-400">
+              Click the star button on any experiment to add it to your favorites
+            </p>
+            <button
+              onClick={() => setFilter('all')}
+              className="mt-4 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+            >
+              Browse All Experiments
+            </button>
+          </div>
+        )}
+
+        {/* Experiments Grid */}
         <div className="grid gap-4">
-          {experiments.map((experiment) => (
-            <Link
+          {filteredExperiments.map((experiment) => (
+            <div
               key={experiment.id}
-              href={`/experiments/${experiment.slug}`}
-              className="p-6 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg hover:shadow-md transition-shadow block"
+              className="p-6 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg hover:shadow-md transition-shadow"
             >
               <div className="flex items-start justify-between">
-                <div className="flex-1">
+                <Link
+                  href={`/experiments/${experiment.slug}`}
+                  className="flex-1"
+                >
                   <h2 className="text-2xl font-semibold mb-2">
                     {experiment.title}
                   </h2>
@@ -48,9 +105,34 @@ export default function ExperimentsPage() {
                       {experiment.createdAt}
                     </span>
                   </div>
-                </div>
+                </Link>
+
+                {/* Favorite Button */}
+                <button
+                  onClick={() => toggleFavorite(experiment.id)}
+                  className="ml-4 p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+                  aria-label={isFavorite(experiment.id) ? 'Remove from favorites' : 'Add to favorites'}
+                >
+                  <svg
+                    className={`w-6 h-6 transition-colors ${
+                      isFavorite(experiment.id)
+                        ? 'text-yellow-500 fill-yellow-500'
+                        : 'text-gray-400 hover:text-yellow-400'
+                    }`}
+                    fill={isFavorite(experiment.id) ? 'currentColor' : 'none'}
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z"
+                    />
+                  </svg>
+                </button>
               </div>
-            </Link>
+            </div>
           ))}
         </div>
       </div>

--- a/experiments/feature-003/spec.md
+++ b/experiments/feature-003/spec.md
@@ -1,0 +1,19 @@
+# feature-003: Experiment Favorites (localStorage)
+
+## Purpose
+Allow users to bookmark their favorite experiments for quick access.
+
+## Method
+- Star button on each experiment card
+- localStorage for persistent storage
+- Filter tabs: All / Favorites
+- Empty state UI when no favorites
+
+## Input/Output
+- Input: User clicks star button
+- Output: Favorites list saved to localStorage, UI updates
+
+## Constraints
+- Client-side only (localStorage)
+- No external APIs
+- Accessible UI (ARIA labels)

--- a/hooks/useFavorites.ts
+++ b/hooks/useFavorites.ts
@@ -1,0 +1,72 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react';
+
+const STORAGE_KEY = 'tf-prd-lab-favorites';
+
+export function useFavorites() {
+  const [favorites, setFavorites] = useState<string[]>([]);
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  // Load from localStorage on mount
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored) {
+        setFavorites(JSON.parse(stored));
+      }
+    } catch (error) {
+      console.error('Failed to load favorites:', error);
+    }
+    setIsLoaded(true);
+  }, []);
+
+  // Save to localStorage when favorites change
+  useEffect(() => {
+    if (isLoaded) {
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(favorites));
+      } catch (error) {
+        console.error('Failed to save favorites:', error);
+      }
+    }
+  }, [favorites, isLoaded]);
+
+  const toggleFavorite = useCallback((experimentId: string) => {
+    setFavorites(prev => {
+      if (prev.includes(experimentId)) {
+        return prev.filter(id => id !== experimentId);
+      }
+      return [...prev, experimentId];
+    });
+  }, []);
+
+  const isFavorite = useCallback((experimentId: string) => {
+    return favorites.includes(experimentId);
+  }, [favorites]);
+
+  const addFavorite = useCallback((experimentId: string) => {
+    setFavorites(prev => {
+      if (prev.includes(experimentId)) return prev;
+      return [...prev, experimentId];
+    });
+  }, []);
+
+  const removeFavorite = useCallback((experimentId: string) => {
+    setFavorites(prev => prev.filter(id => id !== experimentId));
+  }, []);
+
+  const clearFavorites = useCallback(() => {
+    setFavorites([]);
+  }, []);
+
+  return {
+    favorites,
+    isLoaded,
+    toggleFavorite,
+    isFavorite,
+    addFavorite,
+    removeFavorite,
+    clearFavorites,
+  };
+}


### PR DESCRIPTION
## 개요

실험 즐겨찾기 기능 추가 (Issue #14)

## 변경 사항

- `hooks/useFavorites.ts`: localStorage CRUD 훅
- `app/experiments/page.tsx`: 'use client' 변환 + 즐겨찾기 기능 추가
- `experiments/feature-003/spec.md\*: 기능 스펙 문서

## 기능

- ⭐ 즐겨찾기 버튼: 각 실험 카드에 별 버튼 추가
- localStorage 저장: 새로고침필도 유지
- 필터 탭: All / Favorites 전환
- 빈 상태 UI: 즐겨찾기 없을 때 안내
- 접근성: ARIA 레이블 추가

## 완료 기준

- [x] 실험 카드에 즐겨찾기 버튼 추가
- [x] localStorage CRUD 구현
- [x] 즐겨찾기 필터 탭 추가
- [x] 빈 즐겨찾기 상태 UI
- [x] pnpm build 성공

## 검증 방법

- [x] `pnpm build` 성공 (12개 정적 페이지)
- [x] 즐겨찾기 토글 동작 확인
- [x] localStorage 저장/복원 확인
- [x] 필터 탭 전환 확인
- [x] 빈 상태 UI 확인

## 기술 스택

- React useState, useEffect, useCallback
- localStorage API
- TypeScript
- Tailwind CSS

## PRD 준수

- 작은 단위 기능 ✅
- 브랜치 + PR workflow ✅
- main 직접 push 금지 ✅
- 문서 포함 ✅

## 관련 이슈

Resolves #14