### PR TITLE
Fix viz-001 blank/too-dark canvas (reset globalAlpha)

### DIFF
--- a/experiments/viz-001/demo.tsx
+++ b/experiments/viz-001/demo.tsx
@@ -53,6 +53,10 @@ export default function ParticleDemo() {
 
     // Animation loop
     const animate = () => {
+      // Reset drawing state each frame to avoid state-leak issues (e.g., globalAlpha)
+      // that can make the canvas appear blank/too dark.
+      ctx.globalAlpha = 1
+
       ctx.fillStyle = 'rgba(0, 0, 0, 0.1)'
       ctx.fillRect(0, 0, canvas.width, canvas.height)
 


### PR DESCRIPTION
### What\n- Reset canvas 2D context state at the start of each animation frame (ctx.globalAlpha = 1).\n\n### Why\n- Prevents state-leak across frames that can make viz-001 appear blank/too dark even though the canvas is present and RAF is running.\n\n### Notes\n- Observed pixel readback after manual draw returning non-magenta, indicating the frame loop immediately overwrites the canvas.