### PR TITLE
viz-001: make particles clearly visible (solid clear + debug marker)

### DIFF
--- a/experiments/viz-001/demo.tsx
+++ b/experiments/viz-001/demo.tsx
@@ -43,9 +43,10 @@ export default function ParticleDemo() {
           y: Math.random() * canvas.height,
           vx: (Math.random() - 0.5) * 2,
           vy: (Math.random() - 0.5) * 2,
-          radius: Math.random() * 3 + 1,
+          // Make particles more visible across devices (avoid near-invisible tiny/low-alpha dots)
+          radius: Math.random() * 4 + 2,
           color: colors[Math.floor(Math.random() * colors.length)],
-          alpha: Math.random() * 0.5 + 0.5,
+          alpha: 1,
         })
       }
 
@@ -61,9 +62,14 @@ export default function ParticleDemo() {
       // Reset state each frame (prevents state leak causing blank/too-dark canvas)
       ctx.globalAlpha = 1
 
-      // Fade background slightly for trails
-      ctx.fillStyle = 'rgba(0, 0, 0, 0.1)'
+      // Clear to solid black each frame for maximum visibility (avoid accumulating near-black haze)
+      ctx.fillStyle = '#000'
       ctx.fillRect(0, 0, canvas.width, canvas.height)
+
+      // Debug marker (top-left) to confirm drawing is visible on screen
+      ctx.fillStyle = '#ffffff'
+      ctx.globalAlpha = 1
+      ctx.fillRect(0, 0, 6, 6)
 
       const particles = particlesRef.current
 
@@ -120,7 +126,8 @@ export default function ParticleDemo() {
             ctx.moveTo(newX, newY)
             ctx.lineTo(prev.x, prev.y)
             ctx.strokeStyle = p.color
-            ctx.globalAlpha = 0.2
+            ctx.globalAlpha = 0.5
+            ctx.lineWidth = 1
             ctx.stroke()
           }
         }


### PR DESCRIPTION
### Context\nOn your device, canvas is visible (border shows) and pixel sampling reports non-black pixels, yet visually it appears blank.\n\n### Change\n- Clear to solid black each frame (no low-alpha haze accumulation)\n- Increase particle radius + force alpha=1\n- Strengthen trail alpha\n- Add a tiny white debug marker at (0,0) to confirm drawing output is visible\n\nThis should make viz-001 unmistakably visible on all displays.