### PR TITLE
Fix Tailwind CSS scan to include experiments/*

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -6,6 +6,7 @@ const config: Config = {
     "./pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./components/**/*.{js,ts,jsx,tsx,mdx}",
     "./app/**/*.{js,ts,jsx,tsx,mdx}",
+    "./experiments/**/*.{js,ts,jsx,tsx,mdx}",
   ],
   theme: {
     extend: {},


### PR DESCRIPTION
Tailwind content globs did not include ./experiments/** so utilities used in experiment demos (e.g., h-screen, inset-0) were not generated in the production CSS, causing layout collapse/clipping.\n\nAdd: ./experiments/**/*.{js,ts,jsx,tsx,mdx}