### PR TITLE
feat: add Copy link button with toast on experiment detail pages

### DIFF
--- a/app/experiments/game-001/page.tsx
+++ b/app/experiments/game-001/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import Link from 'next/link'
 import dynamic from 'next/dynamic'
+import { ExperimentPageActions } from '@/components/ExperimentPageActions'
 
 const CatchGameDemo = dynamic(() => import('@/experiments/game-001/demo'), {
   ssr: false,
@@ -15,14 +15,10 @@ const CatchGameDemo = dynamic(() => import('@/experiments/game-001/demo'), {
 export default function Game001Page() {
   return (
     <main className="min-h-screen">
-      <nav className="fixed top-4 right-4 z-10">
-        <Link
-          href="/experiments"
-          className="px-4 py-2 bg-black/50 backdrop-blur-sm text-white rounded-lg hover:bg-black/70 transition-colors"
-        >
-          ← Back to Experiments
-        </Link>
-      </nav>
+      <ExperimentPageActions
+        backClassName="px-4 py-2 bg-black/50 backdrop-blur-sm text-white rounded-lg hover:bg-black/70 transition-colors"
+        copyClassName="px-4 py-2 bg-black/50 backdrop-blur-sm text-white rounded-lg hover:bg-black/70 transition-colors"
+      />
       <CatchGameDemo />
     </main>
   )

--- a/app/experiments/game-002/page.tsx
+++ b/app/experiments/game-002/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import Link from 'next/link'
 import dynamic from 'next/dynamic'
+import { ExperimentPageActions } from '@/components/ExperimentPageActions'
 
 const AimTrainerGameDemo = dynamic(() => import('@/experiments/game-002/demo'), {
   ssr: false,
@@ -15,14 +15,10 @@ const AimTrainerGameDemo = dynamic(() => import('@/experiments/game-002/demo'), 
 export default function Game002Page() {
   return (
     <main className="min-h-screen">
-      <nav className="fixed top-4 right-4 z-10">
-        <Link
-          href="/experiments"
-          className="px-4 py-2 bg-black/50 backdrop-blur-sm text-white rounded-lg hover:bg-black/70 transition-colors"
-        >
-          ← Back to Experiments
-        </Link>
-      </nav>
+      <ExperimentPageActions
+        backClassName="px-4 py-2 bg-black/50 backdrop-blur-sm text-white rounded-lg hover:bg-black/70 transition-colors"
+        copyClassName="px-4 py-2 bg-black/50 backdrop-blur-sm text-white rounded-lg hover:bg-black/70 transition-colors"
+      />
       <AimTrainerGameDemo />
     </main>
   )

--- a/app/experiments/tool-001/page.tsx
+++ b/app/experiments/tool-001/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import Link from "next/link";
 import dynamic from "next/dynamic";
+import { ExperimentPageActions } from '@/components/ExperimentPageActions'
 
 const ColorPickerDemo = dynamic(() => import("@/experiments/tool-001/demo"), {
   ssr: false,
@@ -15,14 +15,10 @@ const ColorPickerDemo = dynamic(() => import("@/experiments/tool-001/demo"), {
 export default function Tool001Page() {
   return (
     <main className="min-h-screen">
-      <nav className="fixed top-4 right-4 z-10">
-        <Link
-          href="/experiments"
-          className="px-4 py-2 bg-gray-900/50 dark:bg-gray-100/50 backdrop-blur-sm text-white dark:text-gray-900 rounded-lg hover:bg-gray-900/70 dark:hover:bg-gray-100/70 transition-colors"
-        >
-          ← Back to Experiments
-        </Link>
-      </nav>
+      <ExperimentPageActions
+        backClassName="px-4 py-2 bg-gray-900/50 dark:bg-gray-100/50 backdrop-blur-sm text-white dark:text-gray-900 rounded-lg hover:bg-gray-900/70 dark:hover:bg-gray-100/70 transition-colors"
+        copyClassName="px-4 py-2 bg-gray-900/50 dark:bg-gray-100/50 backdrop-blur-sm text-white dark:text-gray-900 rounded-lg hover:bg-gray-900/70 dark:hover:bg-gray-100/70 transition-colors"
+      />
 
       <ColorPickerDemo />
     </main>

--- a/app/experiments/tool-002/page.tsx
+++ b/app/experiments/tool-002/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import Link from "next/link";
 import dynamic from "next/dynamic";
+import { ExperimentPageActions } from '@/components/ExperimentPageActions'
 
 const JsonFormatterDemo = dynamic(() => import("@/experiments/tool-002/demo"), {
   ssr: false,
@@ -15,14 +15,10 @@ const JsonFormatterDemo = dynamic(() => import("@/experiments/tool-002/demo"), {
 export default function Tool002Page() {
   return (
     <main className="min-h-screen">
-      <nav className="fixed top-4 right-4 z-10">
-        <Link
-          href="/experiments"
-          className="px-4 py-2 bg-gray-900/80 backdrop-blur-sm text-white rounded-lg hover:bg-gray-800 transition-colors"
-        >
-          ← Back to Experiments
-        </Link>
-      </nav>
+      <ExperimentPageActions
+        backClassName="px-4 py-2 bg-gray-900/80 backdrop-blur-sm text-white rounded-lg hover:bg-gray-800 transition-colors"
+        copyClassName="px-4 py-2 bg-gray-900/80 backdrop-blur-sm text-white rounded-lg hover:bg-gray-800 transition-colors"
+      />
 
       <JsonFormatterDemo />
     </main>

--- a/app/experiments/viz-001/page.tsx
+++ b/app/experiments/viz-001/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import Link from "next/link";
 import dynamic from "next/dynamic";
+import { ExperimentPageActions } from '@/components/ExperimentPageActions'
 
 // Dynamically import the demo component to ensure client-side only rendering
 const ParticleDemo = dynamic(() => import("../../../experiments/viz-001/demo"), {
@@ -17,14 +17,10 @@ export default function Viz001Page() {
   return (
     <>
       <ParticleDemo />
-      <nav className="fixed top-4 right-4 z-10">
-        <Link
-          href="/experiments"
-          className="px-4 py-2 bg-black/50 backdrop-blur-sm text-white rounded-lg hover:bg-black/70 transition-colors"
-        >
-          ← Back to Experiments
-        </Link>
-      </nav>
+      <ExperimentPageActions
+        backClassName="px-4 py-2 bg-black/50 backdrop-blur-sm text-white rounded-lg hover:bg-black/70 transition-colors"
+        copyClassName="px-4 py-2 bg-black/50 backdrop-blur-sm text-white rounded-lg hover:bg-black/70 transition-colors"
+      />
     </>
   );
 }

--- a/app/experiments/viz-002/page.tsx
+++ b/app/experiments/viz-002/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import Link from "next/link";
 import dynamic from "next/dynamic";
+import { ExperimentPageActions } from '@/components/ExperimentPageActions'
 
 const FractalDemo = dynamic(() => import("@/experiments/viz-002/demo"), {
   ssr: false,
@@ -15,14 +15,10 @@ const FractalDemo = dynamic(() => import("@/experiments/viz-002/demo"), {
 export default function Viz002Page() {
   return (
     <main className="min-h-screen">
-      <nav className="fixed top-4 right-4 z-10">
-        <Link
-          href="/experiments"
-          className="px-4 py-2 bg-gray-900/80 backdrop-blur-sm text-white rounded-lg hover:bg-gray-800 transition-colors"
-        >
-          ← Back to Experiments
-        </Link>
-      </nav>
+      <ExperimentPageActions
+        backClassName="px-4 py-2 bg-gray-900/80 backdrop-blur-sm text-white rounded-lg hover:bg-gray-800 transition-colors"
+        copyClassName="px-4 py-2 bg-gray-900/80 backdrop-blur-sm text-white rounded-lg hover:bg-gray-800 transition-colors"
+      />
 
       <FractalDemo />
     </main>

--- a/app/experiments/viz-003/page.tsx
+++ b/app/experiments/viz-003/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import Link from 'next/link'
 import dynamic from 'next/dynamic'
+import { ExperimentPageActions } from '@/components/ExperimentPageActions'
 
 const LissajousDemo = dynamic(() => import('@/experiments/viz-003/demo'), {
   ssr: false,
@@ -15,14 +15,10 @@ const LissajousDemo = dynamic(() => import('@/experiments/viz-003/demo'), {
 export default function Viz003Page() {
   return (
     <main className="min-h-screen">
-      <nav className="fixed top-4 right-4 z-10">
-        <Link
-          href="/experiments"
-          className="px-4 py-2 bg-slate-950/80 backdrop-blur-sm text-white rounded-lg hover:bg-slate-900 transition-colors"
-        >
-          ← Back to Experiments
-        </Link>
-      </nav>
+      <ExperimentPageActions
+        backClassName="px-4 py-2 bg-slate-950/80 backdrop-blur-sm text-white rounded-lg hover:bg-slate-900 transition-colors"
+        copyClassName="px-4 py-2 bg-slate-950/80 backdrop-blur-sm text-white rounded-lg hover:bg-slate-900 transition-colors"
+      />
 
       <LissajousDemo />
     </main>

--- a/app/experiments/viz-004/page.tsx
+++ b/app/experiments/viz-004/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import Link from 'next/link'
 import dynamic from 'next/dynamic'
+import { ExperimentPageActions } from '@/components/ExperimentPageActions'
 
 const MoireWarpDemo = dynamic(() => import('@/experiments/viz-004/demo'), {
   ssr: false,
@@ -15,14 +15,10 @@ const MoireWarpDemo = dynamic(() => import('@/experiments/viz-004/demo'), {
 export default function Viz004Page() {
   return (
     <main className="min-h-screen">
-      <nav className="fixed top-4 right-4 z-10">
-        <Link
-          href="/experiments"
-          className="px-4 py-2 bg-slate-950/80 backdrop-blur-sm text-white rounded-lg hover:bg-slate-900 transition-colors"
-        >
-          ← Back to Experiments
-        </Link>
-      </nav>
+      <ExperimentPageActions
+        backClassName="px-4 py-2 bg-slate-950/80 backdrop-blur-sm text-white rounded-lg hover:bg-slate-900 transition-colors"
+        copyClassName="px-4 py-2 bg-slate-950/80 backdrop-blur-sm text-white rounded-lg hover:bg-slate-900 transition-colors"
+      />
 
       <MoireWarpDemo />
     </main>

--- a/app/experiments/viz-005/page.tsx
+++ b/app/experiments/viz-005/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import Link from 'next/link'
 import dynamic from 'next/dynamic'
+import { ExperimentPageActions } from '@/components/ExperimentPageActions'
 
 const Viz005Demo = dynamic(() => import('@/experiments/viz-005/demo'), {
   ssr: false,
@@ -15,14 +15,10 @@ const Viz005Demo = dynamic(() => import('@/experiments/viz-005/demo'), {
 export default function Viz005Page() {
   return (
     <main className="min-h-screen">
-      <nav className="fixed top-4 right-4 z-10">
-        <Link
-          href="/experiments"
-          className="px-4 py-2 bg-slate-950/80 backdrop-blur-sm text-white rounded-lg hover:bg-slate-900 transition-colors"
-        >
-          ← Back to Experiments
-        </Link>
-      </nav>
+      <ExperimentPageActions
+        backClassName="px-4 py-2 bg-slate-950/80 backdrop-blur-sm text-white rounded-lg hover:bg-slate-900 transition-colors"
+        copyClassName="px-4 py-2 bg-slate-950/80 backdrop-blur-sm text-white rounded-lg hover:bg-slate-900 transition-colors"
+      />
 
       <Viz005Demo />
     </main>

--- a/app/experiments/weird-001/page.tsx
+++ b/app/experiments/weird-001/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import Link from "next/link";
 import dynamic from "next/dynamic";
+import { ExperimentPageActions } from '@/components/ExperimentPageActions'
 
 const GravityReversalDemo = dynamic(() => import("@/experiments/weird-001/demo"), {
   ssr: false,
@@ -15,14 +15,10 @@ const GravityReversalDemo = dynamic(() => import("@/experiments/weird-001/demo")
 export default function Weird001Page() {
   return (
     <main className="min-h-screen">
-      <nav className="fixed top-4 right-4 z-10">
-        <Link
-          href="/experiments"
-          className="px-4 py-2 bg-slate-900/80 backdrop-blur-sm text-white rounded-lg hover:bg-slate-800 transition-colors"
-        >
-          ← Back to Experiments
-        </Link>
-      </nav>
+      <ExperimentPageActions
+        backClassName="px-4 py-2 bg-slate-900/80 backdrop-blur-sm text-white rounded-lg hover:bg-slate-800 transition-colors"
+        copyClassName="px-4 py-2 bg-slate-900/80 backdrop-blur-sm text-white rounded-lg hover:bg-slate-800 transition-colors"
+      />
 
       <GravityReversalDemo />
     </main>

--- a/app/experiments/weird-002/page.tsx
+++ b/app/experiments/weird-002/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import Link from "next/link";
 import dynamic from "next/dynamic";
+import { ExperimentPageActions } from '@/components/ExperimentPageActions'
 
 const GlitchGenerator = dynamic(() => import("@/experiments/weird-002/demo"), {
   ssr: false,
@@ -15,14 +15,10 @@ const GlitchGenerator = dynamic(() => import("@/experiments/weird-002/demo"), {
 export default function Weird002Page() {
   return (
     <main className="min-h-screen">
-      <nav className="fixed top-4 right-4 z-10">
-        <Link
-          href="/experiments"
-          className="px-4 py-2 bg-gray-900/80 backdrop-blur-sm text-white rounded-lg hover:bg-gray-800 transition-colors font-mono"
-        >
-          ← Back to Experiments
-        </Link>
-      </nav>
+      <ExperimentPageActions
+        backClassName="px-4 py-2 bg-gray-900/80 backdrop-blur-sm text-white rounded-lg hover:bg-gray-800 transition-colors font-mono"
+        copyClassName="px-4 py-2 bg-gray-900/80 backdrop-blur-sm text-white rounded-lg hover:bg-gray-800 transition-colors font-mono"
+      />
 
       <GlitchGenerator />
     </main>

--- a/app/experiments/weird-003/page.tsx
+++ b/app/experiments/weird-003/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import Link from "next/link";
 import dynamic from "next/dynamic";
+import { ExperimentPageActions } from '@/components/ExperimentPageActions'
 
 const Weird003Demo = dynamic(() => import("@/experiments/weird-003/demo"), {
   ssr: false,
@@ -15,14 +15,10 @@ const Weird003Demo = dynamic(() => import("@/experiments/weird-003/demo"), {
 export default function Weird003Page() {
   return (
     <main className="min-h-screen">
-      <nav className="fixed top-4 right-4 z-10">
-        <Link
-          href="/experiments"
-          className="px-4 py-2 bg-gray-900/80 backdrop-blur-sm text-white rounded-lg hover:bg-gray-800 transition-colors font-mono"
-        >
-          ← Back to Experiments
-        </Link>
-      </nav>
+      <ExperimentPageActions
+        backClassName="px-4 py-2 bg-gray-900/80 backdrop-blur-sm text-white rounded-lg hover:bg-gray-800 transition-colors font-mono"
+        copyClassName="px-4 py-2 bg-gray-900/80 backdrop-blur-sm text-white rounded-lg hover:bg-gray-800 transition-colors font-mono"
+      />
 
       <Weird003Demo />
     </main>

--- a/components/ExperimentPageActions.tsx
+++ b/components/ExperimentPageActions.tsx
@@ -1,0 +1,119 @@
+'use client'
+
+import Link from 'next/link'
+import { useEffect, useRef, useState } from 'react'
+
+type ToastState = 'success' | 'failure' | null
+
+type ExperimentPageActionsProps = {
+  className?: string
+  backClassName?: string
+  copyClassName?: string
+}
+
+const SUCCESS_MESSAGE = 'Link copied'
+const FAILURE_MESSAGE = 'Couldn’t copy — long-press to copy'
+
+async function copyLink(value: string): Promise<boolean> {
+  if (
+    typeof navigator !== 'undefined' &&
+    navigator.clipboard &&
+    typeof navigator.clipboard.writeText === 'function'
+  ) {
+    try {
+      await navigator.clipboard.writeText(value)
+      return true
+    } catch {
+      // Continue to fallback path.
+    }
+  }
+
+  if (typeof document === 'undefined') {
+    return false
+  }
+
+  const textarea = document.createElement('textarea')
+  textarea.value = value
+  textarea.setAttribute('readonly', '')
+  textarea.style.position = 'fixed'
+  textarea.style.opacity = '0'
+  textarea.style.pointerEvents = 'none'
+
+  document.body.appendChild(textarea)
+  textarea.select()
+  textarea.setSelectionRange(0, textarea.value.length)
+
+  let copied = false
+
+  try {
+    copied = document.execCommand('copy')
+  } catch {
+    copied = false
+  }
+
+  document.body.removeChild(textarea)
+  return copied
+}
+
+export function ExperimentPageActions({
+  className = 'fixed top-4 right-4 z-10 flex items-center gap-2',
+  backClassName = 'px-4 py-2 bg-black/50 backdrop-blur-sm text-white rounded-lg hover:bg-black/70 transition-colors',
+  copyClassName = 'px-4 py-2 bg-black/50 backdrop-blur-sm text-white rounded-lg hover:bg-black/70 transition-colors',
+}: ExperimentPageActionsProps) {
+  const [toastState, setToastState] = useState<ToastState>(null)
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current)
+      }
+    }
+  }, [])
+
+  const showToast = (state: ToastState) => {
+    setToastState(state)
+
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current)
+    }
+
+    timeoutRef.current = setTimeout(() => {
+      setToastState(null)
+      timeoutRef.current = null
+    }, 2200)
+  }
+
+  const handleCopyLink = async () => {
+    if (typeof window === 'undefined') {
+      showToast('failure')
+      return
+    }
+
+    const copied = await copyLink(window.location.href)
+    showToast(copied ? 'success' : 'failure')
+  }
+
+  return (
+    <>
+      <nav className={className}>
+        <Link href="/experiments" className={backClassName}>
+          ← Back to Experiments
+        </Link>
+        <button type="button" onClick={handleCopyLink} className={copyClassName} aria-label="Copy link">
+          Copy link
+        </button>
+      </nav>
+
+      {toastState && (
+        <div
+          role="status"
+          aria-live="polite"
+          className="fixed left-1/2 top-4 z-20 -translate-x-1/2 rounded-md bg-slate-900 px-3 py-2 text-sm text-white shadow-lg"
+        >
+          {toastState === 'success' ? SUCCESS_MESSAGE : FAILURE_MESSAGE}
+        </div>
+      )}
+    </>
+  )
+}


### PR DESCRIPTION
## Summary
- add shared `ExperimentPageActions` component for experiment detail pages
- add accessible `Copy link` button next to existing back action on every experiment detail route
- implement clipboard copy with `navigator.clipboard.writeText` plus `document.execCommand('copy')` fallback
- show toast feedback messages:
  - success: `Link copied`
  - failure: `Couldn’t copy — long-press to copy`
- include SSR-safe guards for `window`, `navigator`, and `document` access

## Testing
- `pnpm lint`
- `pnpm build`

Closes #62
