### PR TITLE
feat: empty state reset action on experiments list

### DIFF
--- a/app/experiments/page.tsx
+++ b/app/experiments/page.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link'
 import { useEffect, useMemo, useState } from 'react'
+import EmptyState from '@/components/EmptyState'
 import { experiments } from '../../experiments/index'
 
 export default function ExperimentsPage() {
@@ -199,20 +200,15 @@ export default function ExperimentsPage() {
         </section>
 
         {filteredExperiments.length === 0 ? (
-          <section className="rounded-xl border border-dashed border-gray-300 p-8 text-center dark:border-gray-700">
-            <h2 className="text-lg font-semibold">No matching experiments</h2>
-            <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
-              Try a different keyword or remove one of the selected tags.
-            </p>
-            {hasActiveFilters && (
-              <button
-                onClick={clearFilters}
-                className="mt-4 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-blue-700"
-              >
-                Reset filters
-              </button>
-            )}
-          </section>
+          <EmptyState
+            title={experiments.length === 0 ? 'No experiments yet' : 'No matching experiments'}
+            description={
+              experiments.length === 0
+                ? 'There are no experiments in the catalog yet. Add one to get started.'
+                : 'Try a different keyword or remove one of the selected tags.'
+            }
+            action={hasActiveFilters ? { label: 'Reset filters', onClick: clearFilters } : undefined}
+          />
         ) : (
           <section className="grid gap-4">
             {filteredExperiments.map((experiment) => (

--- a/components/EmptyState.tsx
+++ b/components/EmptyState.tsx
@@ -1,0 +1,29 @@
+import { ReactNode } from 'react'
+
+type EmptyStateAction = {
+  label: string
+  onClick: () => void
+}
+
+type EmptyStateProps = {
+  title: string
+  description: ReactNode
+  action?: EmptyStateAction
+}
+
+export default function EmptyState({ title, description, action }: EmptyStateProps) {
+  return (
+    <section className="rounded-xl border border-dashed border-gray-300 p-8 text-center dark:border-gray-700">
+      <h2 className="text-lg font-semibold">{title}</h2>
+      <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">{description}</p>
+      {action && (
+        <button
+          onClick={action.onClick}
+          className="mt-4 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-blue-700"
+        >
+          {action.label}
+        </button>
+      )}
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary
- add a reusable EmptyState component with optional action button
- use EmptyState in /experiments list for 0-result scenarios
- distinguish copy between "no data yet" and "no matching results due to filters/search"
- wire "Reset filters" action to restore default search/tag state

## Validation
- manual behavior check: filtering/searching to 0 results shows empty state and reset action
- reset clears search+tags and returns full list
- pnpm build passes

Closes #71
