### PR TITLE
fix: persist /experiments search+tag URL state on initial render (#75)

### DIFF
--- a/app/experiments/ExperimentsClient.tsx
+++ b/app/experiments/ExperimentsClient.tsx
@@ -20,20 +20,6 @@ export default function ExperimentsPage() {
   const router = useRouter()
   const pathname = usePathname()
 
-  const [searchInput, setSearchInput] = useState('')
-  const [selectedTags, setSelectedTags] = useState<string[]>([])
-
-  const deferredSearch = useDeferredValue(searchInput)
-
-  const normalizedExperiments = useMemo(
-    () =>
-      experiments.map((experiment) => ({
-        ...experiment,
-        searchable: `${experiment.title} ${experiment.slug}`.toLowerCase(),
-      })),
-    []
-  )
-
   const validTags = useMemo(() => new Set(experiments.flatMap((experiment) => experiment.tags)), [])
 
   const urlSearchInput = useMemo(() => searchParams.get(SEARCH_PARAM) ?? '', [searchParams])
@@ -46,6 +32,20 @@ export default function ExperimentsPage() {
           .filter((tag) => tag.length > 0 && validTags.has(tag))
       ),
     [searchParams, validTags]
+  )
+
+  const [searchInput, setSearchInput] = useState(urlSearchInput)
+  const [selectedTags, setSelectedTags] = useState<string[]>(urlSelectedTags)
+
+  const deferredSearch = useDeferredValue(searchInput)
+
+  const normalizedExperiments = useMemo(
+    () =>
+      experiments.map((experiment) => ({
+        ...experiment,
+        searchable: `${experiment.title} ${experiment.slug}`.toLowerCase(),
+      })),
+    []
   )
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- keep `/experiments` search text (`q`) and selected tag filters (`tag`) in URL query params
- initialize local UI state from URL-derived values on first render to avoid default-state flash
- retain existing URL↔state synchronization so refresh/back/forward restore the same list state

## UX behavior
- direct-link load (e.g. `/experiments?q=viz&tag=visualization`) now renders with matching search/tag chips already applied
- no params still shows the current default full list
- invalid/empty tag params are ignored, and duplicate tags are normalized

## Verification
- `pnpm lint` ✅
- `pnpm build` ✅
- manual: loaded `/experiments` with query params, refreshed, and navigated back/forward to confirm state restoration

Closes #75
