### PR TITLE
feat: keep experiments filter/search state in URL query

### DIFF
--- a/app/experiments/ExperimentsClient.tsx
+++ b/app/experiments/ExperimentsClient.tsx
@@ -121,6 +121,7 @@ export default function ExperimentsPage() {
   }
 
   const hasActiveFilters = searchInput.trim().length > 0 || selectedTags.length > 0
+  const currentQueryString = searchParams.toString()
 
   return (
     <main className="min-h-screen px-4 py-6 sm:px-6 sm:py-8">
@@ -225,7 +226,11 @@ export default function ExperimentsPage() {
             {filteredExperiments.map((experiment) => (
               <Link
                 key={experiment.id}
-                href={`/experiments/${experiment.slug}`}
+                href={
+                  currentQueryString.length > 0
+                    ? `/experiments/${experiment.slug}?${currentQueryString}`
+                    : `/experiments/${experiment.slug}`
+                }
                 className="block rounded-xl border border-gray-200 bg-white p-4 shadow-sm transition hover:shadow-md dark:border-gray-700 dark:bg-gray-900 sm:p-5"
               >
                 <div className="flex items-start justify-between gap-3">

--- a/components/ExperimentPageActions.tsx
+++ b/components/ExperimentPageActions.tsx
@@ -13,6 +13,27 @@ type ExperimentPageActionsProps = {
 
 const SUCCESS_MESSAGE = 'Link copied'
 const FAILURE_MESSAGE = 'Couldn’t copy — long-press to copy'
+const SEARCH_PARAM = 'q'
+const TAG_PARAM = 'tag'
+
+function buildExperimentsBackHref(queryString: string): string {
+  const sourceParams = new URLSearchParams(queryString)
+  const nextParams = new URLSearchParams()
+
+  const query = sourceParams.get(SEARCH_PARAM)?.trim()
+  if (query && query.length > 0) {
+    nextParams.set(SEARCH_PARAM, query)
+  }
+
+  sourceParams
+    .getAll(TAG_PARAM)
+    .map((tag) => tag.trim())
+    .filter((tag) => tag.length > 0)
+    .forEach((tag) => nextParams.append(TAG_PARAM, tag))
+
+  const nextQueryString = nextParams.toString()
+  return nextQueryString.length > 0 ? `/experiments?${nextQueryString}` : '/experiments'
+}
 
 async function copyLink(value: string): Promise<boolean> {
   if (
@@ -61,7 +82,16 @@ export function ExperimentPageActions({
   copyClassName = 'px-4 py-2 bg-black/50 backdrop-blur-sm text-white rounded-lg hover:bg-black/70 transition-colors',
 }: ExperimentPageActionsProps) {
   const [toastState, setToastState] = useState<ToastState>(null)
+  const [backHref, setBackHref] = useState('/experiments')
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    setBackHref(buildExperimentsBackHref(window.location.search))
+  }, [])
 
   useEffect(() => {
     return () => {
@@ -97,7 +127,7 @@ export function ExperimentPageActions({
   return (
     <>
       <nav className={className}>
-        <Link href="/experiments" className={backClassName}>
+        <Link href={backHref} className={backClassName}>
           ← Back to Experiments
         </Link>
         <button type="button" onClick={handleCopyLink} className={copyClassName} aria-label="Copy link">


### PR DESCRIPTION
## Summary
- keep current experiments list query params (`q`, `tag`) when navigating from list to experiment detail
- update detail-page "Back to Experiments" action to restore list URL with the same query params
- keeps existing list-side URL <-> state sync behavior and makes round-trip navigation preserve filtered state reliably

Closes #82

## Manual test notes
- [x] On `/experiments`, set search + one/more tags and confirm URL updates (`?q=...&tag=...`)
- [x] Refresh page and verify same filtered list remains
- [x] Open an experiment card, then click "← Back to Experiments" and verify filters/search are preserved
- [x] Copy/share filtered list URL and open in a new tab; verify same filtered state loads
- [x] Clear filters and confirm URL returns to bare `/experiments`

## Validation
- `pnpm lint` ✅
- `pnpm build` ✅ (passes; existing @next/swc version mismatch warnings remain)
