### PR TITLE
fix: preserve /experiments tag filter states in browser history

### DIFF
--- a/app/experiments/ExperimentsClient.tsx
+++ b/app/experiments/ExperimentsClient.tsx
@@ -34,7 +34,6 @@ export default function ExperimentsPage() {
   const [searchInput, setSearchInput] = useState(urlSearchInput)
   const [selectedTags, setSelectedTags] = useState<string[]>(urlSelectedTags)
   const updateModeRef = useRef<'push' | 'replace'>('replace')
-  const lastTagInteractionAtRef = useRef(0)
 
   const deferredSearch = useDeferredValue(searchInput)
 
@@ -121,9 +120,7 @@ export default function ExperimentsPage() {
   }, [deferredSearch, normalizedExperiments, selectedTags])
 
   const toggleTag = (tag: string) => {
-    const now = Date.now()
-    updateModeRef.current = now - lastTagInteractionAtRef.current < 800 ? 'replace' : 'push'
-    lastTagInteractionAtRef.current = now
+    updateModeRef.current = 'push'
 
     setSelectedTags((prev) =>
       prev.includes(tag) ? prev.filter((selected) => selected !== tag) : [...prev, tag]


### PR DESCRIPTION
## Summary
- keep URL query sync behavior for `/experiments` filters
- always push history entries on tag toggle so back/forward restores prior tag states
- keep search typing behavior as replace to avoid noisy history entries

## Why
Issue #95 asks for filter state restoration across refresh and browser navigation. Query param sync already exists; this change tightens back/forward restoration for tag interactions with minimal code changes.

## Verification
- `pnpm lint`
- `pnpm build`
- manual: on `/experiments`, toggle tags multiple times, then use browser back/forward to confirm state restoration

Fixes #95
