### PR TITLE
Fix /experiments URL filter sync back-forward behavior

### DIFF
--- a/app/experiments/ExperimentsClient.tsx
+++ b/app/experiments/ExperimentsClient.tsx
@@ -34,6 +34,7 @@ export default function ExperimentsPage() {
   const [searchInput, setSearchInput] = useState(urlSearchInput)
   const [selectedTags, setSelectedTags] = useState<string[]>(urlSelectedTags)
   const updateModeRef = useRef<'push' | 'replace'>('replace')
+  const skipNextUrlSyncRef = useRef(false)
 
   const deferredSearch = useDeferredValue(searchInput)
 
@@ -47,16 +48,30 @@ export default function ExperimentsPage() {
   )
 
   useEffect(() => {
-    if (searchInput !== urlSearchInput) {
+    const shouldSyncSearch = searchInput !== urlSearchInput
+    const shouldSyncTags = !areEqualArrays(selectedTags, urlSelectedTags)
+
+    if (!shouldSyncSearch && !shouldSyncTags) {
+      return
+    }
+
+    skipNextUrlSyncRef.current = true
+
+    if (shouldSyncSearch) {
       setSearchInput(urlSearchInput)
     }
 
-    if (!areEqualArrays(selectedTags, urlSelectedTags)) {
+    if (shouldSyncTags) {
       setSelectedTags(urlSelectedTags)
     }
   }, [searchInput, selectedTags, urlSearchInput, urlSelectedTags])
 
   useEffect(() => {
+    if (skipNextUrlSyncRef.current) {
+      skipNextUrlSyncRef.current = false
+      return
+    }
+
     const normalizedSelectedTags = normalizeTags(selectedTags)
     const trimmedSearch = searchInput.trim()
 


### PR DESCRIPTION
## Summary
- keep `q` and `tags` as canonical URL filter params for `/experiments`
- prevent URL re-write loops when state is being hydrated from URL/search params
- preserve browser back/forward traversal by skipping one URL-sync cycle after popstate-driven state hydration

## Why
The list page already encoded filters in URL, but popstate/back-forward could be immediately overwritten by stale local state because the URL-update effect ran before local state hydration completed.

## Validation
- `pnpm build` ✅

Closes #97
