### PR TITLE
fix: stabilize experiments filter URL sync state

### DIFF
--- a/app/experiments/ExperimentsClient.tsx
+++ b/app/experiments/ExperimentsClient.tsx
@@ -137,9 +137,13 @@ export default function ExperimentsPage() {
   const toggleTag = (tag: string) => {
     updateModeRef.current = 'push'
 
-    setSelectedTags((prev) =>
-      prev.includes(tag) ? prev.filter((selected) => selected !== tag) : [...prev, tag]
-    )
+    setSelectedTags((prev) => {
+      const nextTags = prev.includes(tag)
+        ? prev.filter((selected) => selected !== tag)
+        : [...prev, tag]
+
+      return normalizeTags(nextTags)
+    })
   }
 
   const clearFilters = () => {


### PR DESCRIPTION
## Summary\n- keep selected tag state normalized in the list page state layer\n- ensure client state and URL query stay in canonical order during tag toggles\n- avoid extra state reconciliation when navigating with back/forward\n\n## Validation\n- pnpm lint\n\nCloses #99