### PR TITLE
Add repo healthcheck runbook + fast CI checks

### DIFF
--- a/.github/workflows/healthcheck.yml
+++ b/.github/workflows/healthcheck.yml
@@ -7,9 +7,14 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: healthcheck-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   healthcheck:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
 # tf-prd-lab
 
 Private sandbox repo to test the OpenClaw team workflow (Planner → Captain → Worker → Judge) with PR-based automation.
+
+## Repo healthcheck
+
+Run the lightweight repository checks locally:
+
+```bash
+pnpm healthcheck
+```
+
+What it checks:
+- required docs files exist
+- local markdown links resolve
+- optional markdown lint (`markdownlint-cli2`) when available
+
+CI also runs the same check on pull requests via `.github/workflows/healthcheck.yml`.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "healthcheck": "bash scripts/healthcheck.sh"
   },
   "dependencies": {
     "@vercel/analytics": "^1.6.1",


### PR DESCRIPTION
## Summary\n- add a documented local 
> tf-prd-lab-20260203@0.1.0 healthcheck /home/higgs/.openclaw/workspace-dev-captain/tf-prd-lab
> bash scripts/healthcheck.sh

[INFO] Checking required docs files...
[INFO]   OK: README.md
[INFO]   OK: docs/PRD.md
[INFO]   OK: docs/PRODUCT_PRD.md
[INFO]   OK: docs/how-to-add-experiment.md
[INFO]   OK: docs/next-actions.md
[INFO] Checking markdown links (local docs links)...
[INFO] Local markdown link check passed.
[INFO] Running optional markdown lint (if available)...
[WARN] markdownlint-cli2 not found; skipping markdown lint

Healthcheck passed. command\n- keep CI healthcheck job lightweight and fast (5 minute timeout + concurrency cancel)\n- document healthcheck behavior and local usage in README\n\n## Validation\n- [INFO] Checking required docs files...
[INFO]   OK: README.md
[INFO]   OK: docs/PRD.md
[INFO]   OK: docs/PRODUCT_PRD.md
[INFO]   OK: docs/how-to-add-experiment.md
[INFO]   OK: docs/next-actions.md
[INFO] Checking markdown links (local docs links)...
[INFO] Local markdown link check passed.
[INFO] Running optional markdown lint (if available)...
[WARN] markdownlint-cli2 not found; skipping markdown lint

Healthcheck passed.\n\nCloses #104