### PR TITLE
CI: run healthcheck on PR + main

### DIFF
--- a/.github/workflows/healthcheck.yml
+++ b/.github/workflows/healthcheck.yml
@@ -2,6 +2,9 @@ name: Repo Healthcheck
 
 on:
   pull_request:
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ What it checks:
 - local markdown links resolve
 - optional markdown lint (`markdownlint-cli2`) when available
 
-CI also runs the same check on pull requests via `.github/workflows/healthcheck.yml`.
+CI also runs the same check on pull requests and pushes to `main` via `.github/workflows/healthcheck.yml`.


### PR DESCRIPTION
## Summary
- keep the existing lightweight `scripts/healthcheck.sh` checks as-is
- update GitHub Actions workflow to run on both pull requests and pushes to `main`
- clarify README wording for local/CI healthcheck behavior

## Validation
- `bash scripts/healthcheck.sh`

Closes #106
