### PR TITLE
docs: ideation SSOT index + run template/archive scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 Private sandbox repo to test the OpenClaw team workflow (Planner → Captain → Worker → Judge) with PR-based automation.
 
+## Documentation entrypoint
+
+- Start here: [docs/INDEX.md](./docs/INDEX.md)
+- Ideation SSOT: [docs/ideation/INDEX.md](./docs/ideation/INDEX.md)
+
 ## Repo healthcheck
 
 Run the lightweight repository checks locally:

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,6 +1,6 @@
 # Docs Index (SSOT Entry)
 
-이 문서는 tf-prd-lab의 문서 엔트리포인트입니다.
+이 문서는 tf-prd-lab 문서의 **공식 시작점(canonical entrypoint)** 입니다.
 
 ## 1) Product & Workflow SSOT
 

--- a/docs/ideation/INDEX.md
+++ b/docs/ideation/INDEX.md
@@ -1,55 +1,34 @@
-# Ideation Index (Next Run)
+# Ideation Index (SSOT)
 
-목표: 다음 실행에서 **무엇을 바로 이슈/작업으로 전환할지 1분 내 판단** 가능하게 유지.
+**1-minute goal:** 이 문서만 열어도 다음 1~2개 실행 액션을 바로 고를 수 있어야 합니다.
 
-## Current Focus (추천 실행 순서)
+## Start Here (Canonical Pointers)
 
-### Card A — docs/next-actions 정리 (중복/상태 정확화)
-- **Why now:** `docs/next-actions.md`에 Ticket 7이 중복되고 상태 표기가 혼재되어 가독성이 떨어짐.
-- **Scope:**
-  - Ticket 중복 제거
-  - DONE / IN_PROGRESS / BLOCKED 표기 규칙 통일
-  - PR/Issue 링크를 `higgs-jung/tf-prd-lab` 기준으로 정규화
-- **Done when:**
-  - 중복 항목 0개
-  - 각 Ticket에 상태 1개만 존재
-  - 깨진 링크 없음(클릭 확인)
+- Repo docs entrypoint: [../INDEX.md](../INDEX.md)
+- Workflow PRD SSOT: [../PRD.md](../PRD.md)
+- Product PRD SSOT: [../PRODUCT_PRD.md](../PRODUCT_PRD.md)
+- Execution backlog: [../next-actions.md](../next-actions.md)
 
-### Card B — Milestone snapshot 문서화
-- **Why now:** 현재 실험/배포 상태를 한 번에 보기 어려움.
-- **Scope:**
-  - `docs/` 하위에 `STATUS.md` 추가
-  - Milestone별 완료/보류/리스크 5줄 이내 요약
-- **Done when:**
-  - 신규 참여자가 `STATUS.md`만 읽고 현재 상태를 설명 가능
+## Next 1–2 Actions (Pick One)
 
----
+### 1) Backlog hygiene: `docs/next-actions.md` 중복/상태 정리
+- Why now: 중복 Ticket(예: Ticket 7)과 상태 혼재로 실행 판단 속도가 느림.
+- Scope: 중복 제거, 상태 라벨(DONE/IN_PROGRESS/BLOCKED) 단일화, 링크 정규화.
+- Done: 티켓별 단일 상태 + 깨진 링크 0.
 
-## Ideation Run Template (간단 체크리스트)
+### 2) Milestone snapshot 문서 추가 (`docs/STATUS.md`)
+- Why now: 신규 참여자가 현재 상태를 한 번에 파악하기 어려움.
+- Scope: Milestone별 완료/보류/리스크를 5~10줄로 요약.
+- Done: `docs/INDEX.md`에서 접근 가능 + 1분 내 상태 설명 가능.
 
-아래 템플릿을 복사해 새 이슈/PRD 메모를 만든다.
+## Runs
 
-```md
-### [제목]
-- Goal (1문장):
-- Why now (1문장):
-- Scope (파일/경로):
-- Out of scope:
+- Active run template: [runs/TEMPLATE.md](./runs/TEMPLATE.md)
+- Archive index: [_archive/README.md](./_archive/README.md)
+- Latest archived run: [_archive/ideation-20260214-0412.md](./_archive/ideation-20260214-0412.md)
 
-#### Done Checklist
-- [ ] 변경 파일이 1~3개 내로 유지됨
-- [ ] 문서 엔트리( docs/INDEX.md )에서 탐색 가능함
-- [ ] 중복/깨진 링크 점검 완료
-- [ ] 다음 실행자가 1분 내 시작 가능함
+## 운영 규칙 (간단)
 
-#### Validation
-- [ ] 로컬 미리보기/렌더 확인
-- [ ] 링크 클릭 점검(상대경로 기준)
-- [ ] PR 설명에 목표/범위/완료조건 기재
-```
-
-## Link Hygiene Rule
-
-- 링크는 상대경로 우선 (`./`, `../`)
-- 문서 엔트리는 `docs/INDEX.md`에서 반드시 연결
-- 동일 티켓 중복 기재 금지 (상태 변경 시 기존 항목 갱신)
+- 새 아이디어는 먼저 run 문서로 기록 후, 검증되면 이슈/백로그로 승격
+- 오래된 run은 삭제하지 말고 `docs/ideation/_archive/`로 이동
+- 문서 탐색은 항상 `docs/INDEX.md`에서 시작 가능해야 함

--- a/docs/ideation/_archive/README.md
+++ b/docs/ideation/_archive/README.md
@@ -1,0 +1,11 @@
+# Ideation Run Archive
+
+과거 ideation run 기록 보관소입니다.
+
+## Rules
+- run 문서는 삭제하지 않고 이 폴더로 이동
+- 파일명 유지: `ideation-YYYYMMDD-HHMM.md`
+- 최신 요약/실행 카드는 `../INDEX.md`에서 관리
+
+## Archived runs
+- [ideation-20260214-0412.md](./ideation-20260214-0412.md)

--- a/docs/ideation/_archive/ideation-20260214-0412.md
+++ b/docs/ideation/_archive/ideation-20260214-0412.md
@@ -1,0 +1,37 @@
+# Ideation run — 2026-02-14 04:12 (Asia/Seoul)
+
+Context: Repo appears idle (no open PRs/issues). Generate 1–2 small, high-leverage next steps.
+
+## Candidate ideas
+
+### A) Repo healthcheck script + CI
+**Problem:** Drift accumulates: broken docs links, missing expected files, inconsistent formatting.
+
+**Proposal:**
+- Add `scripts/healthcheck.sh` that runs:
+  - link check for `docs/**/*.md` (e.g., `lychee` or a small python script)
+  - markdown lint (optional)
+  - verify required docs exist (`docs/INDEX.md`, `docs/PRD.md` if required)
+- Add GitHub Action `healthcheck.yml` to run on PRs.
+
+**Why now:** Very low product risk; improves quality signal for future PRDs.
+
+**Acceptance:**
+- `./scripts/healthcheck.sh` exits non-zero on broken links
+- CI runs on PRs and blocks merges when failing
+
+### B) PRD skeleton + example
+**Problem:** PRDs can be vague; reviewers spend time clarifying basics.
+
+**Proposal:**
+- Add `docs/PRD_TEMPLATE.md` with explicit sections: problem, users, non-goals, success metrics, acceptance tests.
+- Add a tiny example PRD (1 page) showing how to write measurable acceptance.
+
+**Acceptance:**
+- Template exists + linked from `docs/INDEX.md`
+
+## Recommendation
+Pick **A (Repo healthcheck + CI)** first.
+
+## Promote to issue?
+Yes, repo is idle and last promote was >6h ago.

--- a/docs/ideation/runs/TEMPLATE.md
+++ b/docs/ideation/runs/TEMPLATE.md
@@ -1,0 +1,36 @@
+# Ideation Run — YYYY-MM-DD HH:mm (Asia/Seoul)
+
+Context: (현재 상태 요약 1~2문장)
+
+## Candidate Cards
+
+### Card A — <title>
+- Problem:
+- Proposal:
+- Scope (files):
+- Why now:
+- Acceptance:
+
+### Card B — <title>
+- Problem:
+- Proposal:
+- Scope (files):
+- Why now:
+- Acceptance:
+
+## Recommendation (Pick One)
+
+- 선택 카드:
+- 선택 이유(1~2문장):
+
+## Promote to issue/backlog?
+
+- [ ] Yes
+- [ ] No
+- Note:
+
+## Link updates checklist
+
+- [ ] `docs/ideation/INDEX.md`에 최신 상태 반영
+- [ ] 필요 시 `docs/INDEX.md` 링크 갱신
+- [ ] run 종료 시 문서를 `_archive/`로 이동 (삭제 금지)


### PR DESCRIPTION
## Summary
- clarify canonical docs entrypoints (README -> docs/INDEX.md -> ideation SSOT)
- refresh `docs/ideation/INDEX.md` for 1-minute scanability with explicit next 1-2 actions
- add ideation run scaffolding at `docs/ideation/runs/TEMPLATE.md`
- archive older run docs under `docs/ideation/_archive/` without deleting

## Validation
- `pnpm healthcheck`

Closes #108
