### PR TITLE
Add PR and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Report something that is broken or behaving incorrectly.
+title: "[Bug] "
+labels: bug
+assignees: ""
+---
+
+## Summary
+A clear and concise description of the bug.
+
+## Expected behavior
+What you expected to happen.
+
+## Actual behavior
+What actually happened.
+
+## Steps to reproduce
+1. 
+2. 
+3. 
+
+## Environment
+- OS:
+- Browser/Runtime:
+- App version/commit:
+
+## Logs / screenshots
+Add relevant logs, stack traces, screenshots, or videos.
+
+## Additional context
+Anything else that may help triage this issue.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest an improvement or new capability.
+title: "[Feature] "
+labels: enhancement
+assignees: ""
+---
+
+## Problem
+What problem are you trying to solve?
+
+## Proposal
+Describe the solution you'd like.
+
+## Alternatives considered
+Describe any alternatives you've considered.
+
+## Acceptance criteria
+- [ ] 
+- [ ] 
+
+## Additional context
+Add references, mockups, links, or examples.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+## What
+<!-- What changed? Summarize in 2-5 bullets. -->
+-
+
+## Why
+<!-- Why is this needed? Link context/issues. -->
+-
+
+## How to test
+<!-- Steps a reviewer can run to verify. Include commands if relevant. -->
+1. 
+2. 
+3. 
+
+## Risks
+<!-- Any rollout risk, edge cases, or follow-up work? -->
+- Risk level: Low / Medium / High
+- 
+
+## Checklist
+- [ ] Linked issue (e.g., Closes #113)
+- [ ] Scope is focused and PR is reasonably small
+- [ ] Tests added/updated, or N/A explained
+- [ ] Docs/changelog updated, or N/A explained
+- [ ] Self-reviewed changes


### PR DESCRIPTION
## Summary
- add default PR template with What/Why/How to test/Risks/Checklist
- add issue templates for bug reports and feature requests
- disable blank issues so templates are used by default

Closes #113