### PR TITLE
docs: add milestone snapshot status page (#121)

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -19,7 +19,7 @@
 
 ## 4) Status
 
-- [STATUS.md](./STATUS.md) — milestone 진행 스냅샷 (현재 상태 요약, 1-click)
+- [STATUS.md](./STATUS.md) — milestone별 DONE / IN_PROGRESS / BLOCKED / RISKS 스냅샷 (1-click)
 
 ## 5) Reference
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,40 +1,36 @@
 # Milestone Snapshot
 
-_Last updated: 2026-02-17 (Asia/Seoul)_
+_Last updated: 2026-02-18 05:30 (Asia/Seoul)_
 
-이 문서는 현재 milestone 진행 상태를 **DONE / IN_PROGRESS / BLOCKED / RISKS** 기준으로 빠르게 확인하기 위한 스냅샷입니다.
+빠른 컨텍스트 진입용 문서입니다. 자세한 기준/백로그는 아래 문서를 우선 참조하세요.
 
-## Core docs (quick links)
+- 운영 SSOT: [docs/PRD.md](./PRD.md)
+- 제품 SSOT: [docs/PRODUCT_PRD.md](./PRODUCT_PRD.md)
+- 실행 백로그: [docs/next-actions.md](./next-actions.md)
 
-- [PRD.md](./PRD.md)
-- [PRODUCT_PRD.md](./PRODUCT_PRD.md)
-- [next-actions.md](./next-actions.md)
-- [INDEX.md](./INDEX.md)
+## Milestone 0 — Foundation & Workflow
+- **DONE:** PRD/PRODUCT_PRD/INDEX/next-actions 기반의 문서 진입점과 운영 흐름(Planner→Captain→Worker→Judge) 정리 완료.
+- **DONE:** Next.js baseline scaffold, 배포 설정 초안, 실험 템플릿/추가 가이드 확보.
+- **IN_PROGRESS:** 문서 간 상태 동기화(실제 PR/Issue 상태와 스냅샷 정합성) 운영 루틴 고도화 중.
+- **BLOCKED:** 없음(기반 자체는 동작).
+- **RISKS:** 문서 업데이트가 늦어지면 “현재 상태” 신뢰도가 떨어질 수 있음.
 
-## 운영 기반/문서 정비
+## Milestone 1 — Experiments V1
+- **DONE:** `viz-001`, `tool-001` 실험은 머지 완료 상태로 기능/빌드 기준 충족.
+- **IN_PROGRESS:** `weird-001`는 구현/빌드/태깅 및 Draft PR까지 완료, 리뷰/승인 대기.
+- **IN_PROGRESS:** 실험 카테고리 포트폴리오 확장을 위한 다음 카드 발굴은 ideation 트랙에서 지속 중.
+- **BLOCKED:** 리뷰 PASS 전에는 milestone 완료로 확정 불가(`weird-001` PR 대기).
+- **RISKS:** Draft 장기 방치 시 실험 트랙의 체감 진척도와 실제 코드 상태가 분리될 수 있음.
 
-- **DONE**: `docs/INDEX.md`를 SSOT entrypoint로 정리했고, 운영 기준 문서(`PRD.md`)와 제품 방향(`PRODUCT_PRD.md`) 분리가 완료됨.
-- **DONE**: `docs/next-actions.md` 기준으로 티켓 이력/상태를 추적하는 운영 루프가 자리잡음.
-- **IN_PROGRESS**: 문서 간 상호 링크와 최신성(최근 이슈/PR 반영) 유지 작업은 지속 필요.
-- **BLOCKED**: 구조 자체를 막는 블로커는 현재 없음.
-- **RISKS**: 문서 업데이트가 실작업 속도를 못 따라가면 상태 불일치가 누적될 수 있음.
+## Milestone 2 — Deploy & Ops Reliability
+- **DONE:** Vercel 배포 설정 기본 작업은 완료되어 최소 배포 파이프라인 뼈대는 확보.
+- **IN_PROGRESS:** Next.js 404 관련 설정 보정(`vercel.json`) 이슈가 오픈되어 해결 진행 중.
+- **BLOCKED:** GitHub token `workflow` scope 부족으로 workflow 관련 커밋/푸시 경로가 막혀 있음.
+- **BLOCKED:** 상기 blocker 해소 전에는 CI 기반 자동 검증/릴리즈 신뢰도 확보가 제한됨.
+- **RISKS:** 배포/CI 불안정이 지속되면 PR PASS→merge 사이클이 느려지고 운영 비용이 증가함.
 
-## 실험 V1 (카테고리 실험)
-
-- **DONE**: 실험 트랙/문서 템플릿이 정의되어 신규 실험 추가 경로는 확보됨.
-- **IN_PROGRESS**: 일부 실험 결과가 PR 기준으로 정리 중이며, 리뷰-머지 완료가 필요함.
-- **BLOCKED**: 배포/CI 신뢰도 이슈가 남아 실험 결과를 안정적으로 릴리즈하기 어려움.
-- **RISKS**: Draft/대기 PR이 길어질수록 실험 결과의 최신성·재현성이 낮아질 수 있음.
-
-## 배포 안정화
-
-- **DONE**: 문제 구간(Workflow scope, Vercel 404)이 식별되어 대응 포인트는 명확함.
-- **IN_PROGRESS**: CI workflow 권한/트리거 정비 및 Vercel 라우팅 점검 진행 중.
-- **BLOCKED**: 위 이슈 해소 전에는 자동 배포 파이프라인을 신뢰하기 어려움.
-- **RISKS**: 릴리즈 지연으로 운영 피드백 루프가 느려지고, 문서 상태와 실제 배포 상태 괴리가 커질 수 있음.
-
-## Immediate focus (next)
-
-1. CI workflow scope/권한 이슈 해결
-2. Vercel 라우팅·배포 설정 확정
-3. 열려 있는 실험 PR 리뷰/머지로 상태 정합성 회복
+## 1-minute summary
+- 문서/운영 뼈대는 준비됨(Foundation ✅).
+- 실험 트랙은 일부 완료, 핵심 미해결은 `weird-001` 리뷰 대기.
+- 현재 최우선 리스크는 배포/CI 신뢰도(`workflow` scope, Vercel 404).
+- 이 두 blocker를 먼저 해소하면, 이후 실험 추가 속도와 merge 리듬이 안정화됨.


### PR DESCRIPTION
## What
- refresh `docs/STATUS.md` as a milestone snapshot updated to current state
- summarize each milestone with `DONE / IN_PROGRESS / BLOCKED / RISKS` bullets
- keep a 1-minute quick summary and pointers to `docs/PRD.md`, `docs/PRODUCT_PRD.md`, `docs/next-actions.md`
- update `docs/INDEX.md` status line for clear 1-click access

## Why
- Closes #121
- make current repo status understandable in under 1 minute for new contributors

## How to test
1. Open `docs/STATUS.md` and verify each milestone has DONE / IN_PROGRESS / BLOCKED / RISKS summary
2. Open `docs/INDEX.md` and verify Status section links to `docs/STATUS.md`
3. Run `bash scripts/healthcheck.sh` and confirm pass

## Risks
- Risk level: Low
- Snapshot can become stale if not refreshed with issue/PR state changes

## Checklist
- [x] Linked issue (e.g., Closes #113)
- [x] Scope is focused and PR is reasonably small
- [x] Tests added/updated, or N/A explained (N/A: docs-only)
- [x] Docs/changelog updated, or N/A explained
- [x] Self-reviewed changes
