### PR TITLE
docs: reconcile next-actions/STATUS with actual GitHub state (#123)

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,6 @@
 # Milestone Snapshot
 
-_Last updated: 2026-02-18 05:30 (Asia/Seoul)_
+_Last updated: 2026-02-18 16:22 (Asia/Seoul)_
 
 빠른 컨텍스트 진입용 문서입니다. 자세한 기준/백로그는 아래 문서를 우선 참조하세요.
 
@@ -9,28 +9,28 @@ _Last updated: 2026-02-18 05:30 (Asia/Seoul)_
 - 실행 백로그: [docs/next-actions.md](./next-actions.md)
 
 ## Milestone 0 — Foundation & Workflow
-- **DONE:** PRD/PRODUCT_PRD/INDEX/next-actions 기반의 문서 진입점과 운영 흐름(Planner→Captain→Worker→Judge) 정리 완료.
-- **DONE:** Next.js baseline scaffold, 배포 설정 초안, 실험 템플릿/추가 가이드 확보.
-- **IN_PROGRESS:** 문서 간 상태 동기화(실제 PR/Issue 상태와 스냅샷 정합성) 운영 루틴 고도화 중.
-- **BLOCKED:** 없음(기반 자체는 동작).
-- **RISKS:** 문서 업데이트가 늦어지면 “현재 상태” 신뢰도가 떨어질 수 있음.
+- **DONE:** 문서 진입점(PRD/PRODUCT_PRD/INDEX/next-actions) 및 운영 흐름 정리.
+- **DONE:** Next.js baseline/기본 배포 구성/실험 템플릿 반영.
+- **IN_PROGRESS:** 없음.
+- **BLOCKED:** 없음.
+- **RISKS:** 상태 문서 갱신 지연 시 스냅샷 신뢰도 저하 가능.
 
 ## Milestone 1 — Experiments V1
-- **DONE:** `viz-001`, `tool-001` 실험은 머지 완료 상태로 기능/빌드 기준 충족.
-- **IN_PROGRESS:** `weird-001`는 구현/빌드/태깅 및 Draft PR까지 완료, 리뷰/승인 대기.
-- **IN_PROGRESS:** 실험 카테고리 포트폴리오 확장을 위한 다음 카드 발굴은 ideation 트랙에서 지속 중.
-- **BLOCKED:** 리뷰 PASS 전에는 milestone 완료로 확정 불가(`weird-001` PR 대기).
-- **RISKS:** Draft 장기 방치 시 실험 트랙의 체감 진척도와 실제 코드 상태가 분리될 수 있음.
+- **DONE:** `viz-001`, `tool-001`, `weird-001` 포함 기존 V1 핵심 실험 PR 머지 완료.
+- **DONE:** 관련 핵심 티켓(예: #7) closed 상태.
+- **IN_PROGRESS:** 없음.
+- **BLOCKED:** 없음.
+- **RISKS:** 신규 실험 카드 미정의 상태가 길어지면 milestone 이후 추진 속도 저하 가능.
 
 ## Milestone 2 — Deploy & Ops Reliability
-- **DONE:** Vercel 배포 설정 기본 작업은 완료되어 최소 배포 파이프라인 뼈대는 확보.
-- **IN_PROGRESS:** Next.js 404 관련 설정 보정(`vercel.json`) 이슈가 오픈되어 해결 진행 중.
-- **BLOCKED:** GitHub token `workflow` scope 부족으로 workflow 관련 커밋/푸시 경로가 막혀 있음.
-- **BLOCKED:** 상기 blocker 해소 전에는 CI 기반 자동 검증/릴리즈 신뢰도 확보가 제한됨.
-- **RISKS:** 배포/CI 불안정이 지속되면 PR PASS→merge 사이클이 느려지고 운영 비용이 증가함.
+- **DONE:** Vercel Next.js 404 대응 PR(#8) 머지 완료.
+- **DONE:** repo healthcheck + CI 관련 최근 작업들 머지/close 완료.
+- **IN_PROGRESS:** 없음(문서 정합성 개선 작업은 Issue #123로 별도 추적).
+- **BLOCKED:** 없음(문서 기준으로 확인 가능한 오픈 blocker 없음).
+- **RISKS:** CI/배포 이슈 재발 시 즉시 next-actions에 재등록 필요.
 
 ## 1-minute summary
-- 문서/운영 뼈대는 준비됨(Foundation ✅).
-- 실험 트랙은 일부 완료, 핵심 미해결은 `weird-001` 리뷰 대기.
-- 현재 최우선 리스크는 배포/CI 신뢰도(`workflow` scope, Vercel 404).
-- 이 두 blocker를 먼저 해소하면, 이후 실험 추가 속도와 merge 리듬이 안정화됨.
+- 현재 오픈 PR은 없음.
+- 현재 오픈 Issue는 #123(문서 정합성 업데이트) 1건.
+- milestone 관점의 기능/배포 blocker는 현재 기준으로 없음.
+- 이 PR 머지 후 문서 상태와 GitHub 실제 상태가 다시 일치함.

--- a/docs/next-actions.md
+++ b/docs/next-actions.md
@@ -1,75 +1,56 @@
 # Next Actions
 
+_Last updated: 2026-02-18 16:22 (Asia/Seoul)_
+
 상태 라벨 표준: `DONE` | `IN_PROGRESS` | `BLOCKED`
+
+링크 표기 규칙:
+- **Issue:** GitHub Issue 링크 (`/issues/{number}`)
+- **PR:** GitHub Pull Request 링크 (`/pull/{number}`)
+- Ticket에 따라 Issue가 없고 PR만 존재할 수 있음(초기 티켓).
 
 ## Active (IN_PROGRESS / BLOCKED)
 
-### Ticket 1 — CI workflow push unblock (`workflow` scope)
-- **Status:** BLOCKED
+### Ticket 123 — docs state reconcile (this task)
+- **Status:** IN_PROGRESS
 - **Priority:** P0
-- **Estimated:** Small (10–15m)
-- **Issue:** <https://github.com/higgs-jung/tf-prd-lab/issues/1>
-- **PR:** <https://github.com/higgs-jung/tf-prd-lab/pull/1>
-- **Blocker:** GitHub OAuth token에 `workflow` scope 없음
-- **Next step:** scope 추가 후 workflow 커밋/푸시 재시도
-
-### Ticket 8 — Vercel config for Next.js 404 fix
-- **Status:** IN_PROGRESS
-- **Priority:** P1
-- **Estimated:** Small (30m)
-- **Issue:** <https://github.com/higgs-jung/tf-prd-lab/issues/8>
-- **PR:** <https://github.com/higgs-jung/tf-prd-lab/pull/8>
+- **Estimated:** Small (10–20m)
+- **Issue:** <https://github.com/higgs-jung/tf-prd-lab/issues/123>
+- **PR:** (to be created)
 - **DoD:**
-  - [ ] vercel.json 수정
-  - [ ] `pnpm build` 성공
-  - [ ] Vercel 404 해결
-  - [ ] 리뷰 PASS 후 머지
-
-### Ticket 7 — weird-001 weird category experiment
-- **Status:** IN_PROGRESS
-- **Priority:** P1
-- **Estimated:** Medium (1–2h)
-- **Issue:** <https://github.com/higgs-jung/tf-prd-lab/issues/7>
-- **PR:** <https://github.com/higgs-jung/tf-prd-lab/pull/9>
-- **Milestone:** 1 - Experiments V1 (weird category)
-- **DoD:**
-  - [x] weird-001 실험 컴포넌트 완성
-  - [x] 빌드 성공 (`pnpm build`)
-  - [x] 태그 설정 완료
-  - [x] Draft PR 제출
-  - [ ] 리뷰 PASS 후 머지
+  - [ ] `docs/next-actions.md` 상태/링크 정합성 반영
+  - [ ] `docs/STATUS.md` milestone별 IN_PROGRESS/BLOCKED 사실 기반 갱신
+  - [ ] Judge PASS 후 머지
 
 ## Completed (DONE)
 
+### Ticket 1 — CI workflow push unblock (`workflow` scope)
+- **Status:** DONE
+- **Tracking PR:** <https://github.com/higgs-jung/tf-prd-lab/pull/1> (closed)
+- **Note:** Issue가 아닌 PR 기반으로 추적된 초기 티켓
+
 ### Ticket 2 — Next.js baseline scaffold
 - **Status:** DONE
-- **Priority:** P1
-- **Estimated:** Medium (1–2h)
-- **Issue:** <https://github.com/higgs-jung/tf-prd-lab/issues/2>
-- **PR:** <https://github.com/higgs-jung/tf-prd-lab/pull/2>
+- **Tracking PR:** <https://github.com/higgs-jung/tf-prd-lab/pull/2> (merged)
 
 ### Ticket 3 — viz-001 interactive particles
 - **Status:** DONE
-- **Priority:** P1
-- **Estimated:** Medium (1–2h)
-- **Issue:** <https://github.com/higgs-jung/tf-prd-lab/issues/3>
-- **PR:** <https://github.com/higgs-jung/tf-prd-lab/pull/4>
+- **Tracking PR (closed superseded):** <https://github.com/higgs-jung/tf-prd-lab/pull/3> (closed)
+- **Final implementation PR:** <https://github.com/higgs-jung/tf-prd-lab/pull/4> (merged)
 
 ### Ticket 4 — Vercel deployment configuration
 - **Status:** DONE
-- **Priority:** P0
-- **Estimated:** Small (30m)
-- **Issue:** <https://github.com/higgs-jung/tf-prd-lab/issues/4>
-- **PR:** <https://github.com/higgs-jung/tf-prd-lab/pull/6>
+- **Tracking PR:** <https://github.com/higgs-jung/tf-prd-lab/pull/8> (merged)
 
 ### Ticket 5 — tool-001 color picker / gradient generator
 - **Status:** DONE
-- **Priority:** P1
-- **Estimated:** Medium (1–2h)
-- **Issue:** <https://github.com/higgs-jung/tf-prd-lab/issues/5>
-- **PR:** <https://github.com/higgs-jung/tf-prd-lab/pull/5>
-- **Milestone:** 1 - Experiments V1 (tool category)
+- **Tracking PR:** <https://github.com/higgs-jung/tf-prd-lab/pull/5> (merged)
+
+### Ticket 7 — weird-001 weird category experiment
+- **Status:** DONE
+- **Issue:** <https://github.com/higgs-jung/tf-prd-lab/issues/7> (closed)
+- **Implementation PR:** <https://github.com/higgs-jung/tf-prd-lab/pull/9> (merged)
 
 ## Notes
-- 중복 항목 정리: 기존 Ticket 6(Workflow scope 설정)은 Ticket 1의 blocker/next-step에 병합함.
-- 링크 형식 정규화: GitHub 링크를 angle bracket (`<...>`) 형태로 통일.
+- 기존 문서의 Ticket 1/8은 **Issue 링크처럼 보였지만 실제로는 PR 링크**였음. 현재는 `Tracking PR`로 명시.
+- 현재 저장소의 오픈 작업은 Issue #123 1건이며, 오픈 PR은 없음.


### PR DESCRIPTION
## Summary
- reconcile docs/next-actions.md ticket status with actual GitHub state (open/closed/merged)
- clarify link semantics to avoid Issue vs PR confusion (`Issue`, `PR`, `Tracking PR`)
- update docs/STATUS.md milestone IN_PROGRESS/BLOCKED based on current repo facts

## Facts used
- Open PRs: none
- Open Issues: #123 only
- Historical tickets #1/#2/#3/#4/#5/#8 were PR-backed entries; #7 is Issue + PR

Closes #123