### PR TITLE
docs: refresh next-actions + ideation index after #123 merge (#125)

### DIFF
--- a/docs/ideation/.state.json
+++ b/docs/ideation/.state.json
@@ -1,3 +1,3 @@
 {
-  "lastPromoteAtMs": 1770721966607
+  "lastPromoteAtMs": 1771411916171
 }

--- a/docs/ideation/INDEX.md
+++ b/docs/ideation/INDEX.md
@@ -9,23 +9,28 @@
 - Product PRD SSOT: [../PRODUCT_PRD.md](../PRODUCT_PRD.md)
 - Execution backlog: [../next-actions.md](../next-actions.md)
 
+## Recently Completed Cards
+
+- [#123](https://github.com/higgs-jung/tf-prd-lab/issues/123) — docs reconcile (`docs/next-actions.md` + `docs/STATUS.md`) → merged via [PR #124](https://github.com/higgs-jung/tf-prd-lab/pull/124)
+- [#115](https://github.com/higgs-jung/tf-prd-lab/issues/115) — backlog hygiene (`docs/next-actions.md` status/link cleanup) → merged via [PR #116](https://github.com/higgs-jung/tf-prd-lab/pull/116)
+
 ## Next 1–2 Actions (Pick One)
 
-### 1) Backlog hygiene: `docs/next-actions.md` 중복/상태 정리
-- Why now: 중복 Ticket(예: Ticket 7)과 상태 혼재로 실행 판단 속도가 느림.
-- Scope: 중복 제거, 상태 라벨(DONE/IN_PROGRESS/BLOCKED) 단일화, 링크 정규화.
-- Done: 티켓별 단일 상태 + 깨진 링크 0.
-- Tracking issue: [#115](https://github.com/higgs-jung/tf-prd-lab/issues/115)
+### 1) Close current docs sync loop (#125)
+- Why now: 현재 오픈 이슈가 #125 1건이며, 문서 포인터 최신화가 완료되면 backlog 탐색 지연을 줄일 수 있음.
+- Scope: `docs/next-actions.md`, `docs/ideation/INDEX.md`, run 1개, `.state.json` 동기화.
+- Done: 이슈 #125 머지 완료 + 문서 간 포인터 불일치 0.
+- Tracking issue: [#125](https://github.com/higgs-jung/tf-prd-lab/issues/125)
 
-### 2) Milestone snapshot 문서 추가 (`docs/STATUS.md`)
-- Why now: 신규 참여자가 현재 상태를 한 번에 파악하기 어려움.
-- Scope: Milestone별 완료/보류/리스크를 5~10줄로 요약.
-- Done: `docs/INDEX.md`에서 접근 가능 + 1분 내 상태 설명 가능.
+### 2) Next product-facing ticket 1건 발행
+- Why now: 문서 정리 이슈가 거의 마무리 단계라, 다음 구현 사이클 진입을 위한 실행 단위 확보가 필요함.
+- Scope: `docs/PRD.md`/`docs/PRODUCT_PRD.md` 기준으로 Small 사이즈 이슈 1건 정의.
+- Done: Assignee/DoD가 명확한 새 이슈 1건 생성.
 
 ## Runs
 
 - Active run template: [runs/TEMPLATE.md](./runs/TEMPLATE.md)
-- Latest run: [runs/ideation-20260216-0630.md](./runs/ideation-20260216-0630.md)
+- Latest run: [runs/ideation-20260218-1951.md](./runs/ideation-20260218-1951.md)
 - Archive index: [_archive/README.md](./_archive/README.md)
 - Latest archived run: [_archive/ideation-20260214-0412.md](./_archive/ideation-20260214-0412.md)
 

--- a/docs/ideation/runs/ideation-20260218-1951.md
+++ b/docs/ideation/runs/ideation-20260218-1951.md
@@ -1,0 +1,27 @@
+# Ideation Run — 2026-02-18 19:51 (Asia/Seoul)
+
+## Context
+- Trigger: [Issue #125](https://github.com/higgs-jung/tf-prd-lab/issues/125)
+- Goal: 최근 문서 PR 머지 상태를 `next-actions`/`ideation INDEX`에 반영하고 run 포인터를 최신화.
+
+## Decisions
+1. Ticket 123은 이미 closed + PR #124 merged 상태이므로 `DONE`으로 이관.
+2. 현재 오픈 작업은 Issue #125 단일 건, 오픈 PR은 0건으로 문구 통일.
+3. ideation INDEX에 "Recently Completed Cards" 섹션을 추가해 완료 카드 가시성을 높임.
+
+## Changes
+- `docs/next-actions.md`
+  - Ticket 125를 Active로, Ticket 123을 Completed(DONE)로 정리
+  - 오픈 작업/PR 문구를 작성 시점 실제 상태로 갱신
+- `docs/ideation/INDEX.md`
+  - 완료 카드(#123, #115) 반영
+  - Next 1–2 Actions 최신화
+  - Latest run 포인터를 본 문서로 갱신
+- `docs/ideation/.state.json`
+  - `lastPromoteAtMs`를 현재 시각으로 갱신(cooldown)
+
+## DoD Check
+- [x] `docs/next-actions.md`에 Ticket 123이 DONE으로 반영됨
+- [x] `docs/ideation/INDEX.md` Next Actions / Latest run 포인터 갱신됨
+- [x] run 문서 1개 추가됨
+- [x] `.state.json` cooldown 메타데이터 갱신됨

--- a/docs/next-actions.md
+++ b/docs/next-actions.md
@@ -1,6 +1,6 @@
 # Next Actions
 
-_Last updated: 2026-02-18 16:22 (Asia/Seoul)_
+_Last updated: 2026-02-18 19:51 (Asia/Seoul)_
 
 상태 라벨 표준: `DONE` | `IN_PROGRESS` | `BLOCKED`
 
@@ -11,18 +11,24 @@ _Last updated: 2026-02-18 16:22 (Asia/Seoul)_
 
 ## Active (IN_PROGRESS / BLOCKED)
 
-### Ticket 123 — docs state reconcile (this task)
+### Ticket 125 — ideation INDEX + next-actions refresh after recent merges
 - **Status:** IN_PROGRESS
 - **Priority:** P0
 - **Estimated:** Small (10–20m)
-- **Issue:** <https://github.com/higgs-jung/tf-prd-lab/issues/123>
+- **Issue:** <https://github.com/higgs-jung/tf-prd-lab/issues/125>
 - **PR:** (to be created)
 - **DoD:**
-  - [ ] `docs/next-actions.md` 상태/링크 정합성 반영
-  - [ ] `docs/STATUS.md` milestone별 IN_PROGRESS/BLOCKED 사실 기반 갱신
+  - [ ] `docs/next-actions.md`에서 Ticket 123을 DONE으로 정리
+  - [ ] `docs/ideation/INDEX.md` Next 1–2 Actions 및 Latest run 포인터 갱신
+  - [ ] `docs/ideation/runs/` run 1개 추가 + `.state.json` cooldown 갱신
   - [ ] Judge PASS 후 머지
 
 ## Completed (DONE)
+
+### Ticket 123 — Docs: reconcile docs/next-actions.md + STATUS with actual repo state
+- **Status:** DONE
+- **Issue:** <https://github.com/higgs-jung/tf-prd-lab/issues/123> (closed)
+- **Implementation PR:** <https://github.com/higgs-jung/tf-prd-lab/pull/124> (merged)
 
 ### Ticket 1 — CI workflow push unblock (`workflow` scope)
 - **Status:** DONE
@@ -52,5 +58,5 @@ _Last updated: 2026-02-18 16:22 (Asia/Seoul)_
 - **Implementation PR:** <https://github.com/higgs-jung/tf-prd-lab/pull/9> (merged)
 
 ## Notes
-- 기존 문서의 Ticket 1/8은 **Issue 링크처럼 보였지만 실제로는 PR 링크**였음. 현재는 `Tracking PR`로 명시.
-- 현재 저장소의 오픈 작업은 Issue #123 1건이며, 오픈 PR은 없음.
+- 현재 저장소의 오픈 작업은 Issue #125 1건이며, 오픈 PR은 없음. (작성 시점 기준)
+- Ticket 123은 PR #124 머지로 종료되었고, 본 문서에서 DONE으로 이관함.


### PR DESCRIPTION
## Summary
- move Ticket 123 to DONE in `docs/next-actions.md` with merged PR reference
- refresh `docs/ideation/INDEX.md` with completed cards, updated Next 1–2 Actions, and latest run pointer
- add a compact ideation run and update `docs/ideation/.state.json` cooldown timestamp

## Validation
- docs-only changes; no runtime/build impact

Closes #125
