### PR TITLE
feat: deterministic 오늘의 실험 selection (date-seeded)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,20 +3,17 @@
 import Link from "next/link";
 import { useState, useEffect, useMemo, useCallback } from "react";
 import { experiments, Experiment } from "../experiments/index";
+import { getDeterministicExperimentByDate } from "../lib/todays-experiment";
 
-// Get today's experiment based on date (consistent for 24 hours)
-function getTodaysExperiment(): Experiment {
-  const today = new Date();
-  const dayOfYear = Math.floor(
-    (today.getTime() - new Date(today.getFullYear(), 0, 0).getTime()) / (1000 * 60 * 60 * 24)
-  );
-  const index = dayOfYear % experiments.length;
-  return experiments[index];
+// Get today's experiment based on local date (consistent for 24 hours)
+function getTodaysExperiment(): Experiment | null {
+  return getDeterministicExperimentByDate(experiments);
 }
 
 // Get a random experiment different from current
-function getRandomExperiment(currentId: string): Experiment {
-  const others = experiments.filter(e => e.id !== currentId);
+function getRandomExperiment(currentId: string): Experiment | null {
+  const others = experiments.filter((e) => e.id !== currentId);
+  if (others.length === 0) return null;
   return others[Math.floor(Math.random() * others.length)];
 }
 
@@ -29,10 +26,13 @@ export default function Home() {
   }, []);
 
   const handleRandomPick = useCallback(() => {
-    if (todaysExperiment) {
-      setTodaysExperiment(getRandomExperiment(todaysExperiment.id));
-      setIsRandom(true);
-    }
+    if (!todaysExperiment) return;
+
+    const nextExperiment = getRandomExperiment(todaysExperiment.id);
+    if (!nextExperiment) return;
+
+    setTodaysExperiment(nextExperiment);
+    setIsRandom(true);
   }, [todaysExperiment]);
 
   const handleResetToToday = useCallback(() => {

--- a/docs/verification/issue-127-deterministic-today-experiment.md
+++ b/docs/verification/issue-127-deterministic-today-experiment.md
@@ -1,0 +1,32 @@
+# Issue #127 Verification (Smoke)
+
+## What changed
+- `lib/todays-experiment.ts` adds date-seeded deterministic selection.
+- `app/page.tsx` uses the helper for "오늘의 실험".
+- Edge cases:
+  - Empty experiment list => `null`
+  - Single experiment list => always that experiment
+
+## Smoke steps
+
+1. Start local server.
+   ```bash
+   pnpm dev
+   ```
+2. Open `/` and note the shown "오늘의 실험" title.
+3. Refresh multiple times on the same day.
+   - Expected: same experiment stays selected.
+4. Simulate next day by temporarily changing call site to:
+   ```ts
+   getDeterministicExperimentByDate(experiments, new Date("2026-02-20T09:00:00"))
+   ```
+   and compare with:
+   ```ts
+   getDeterministicExperimentByDate(experiments, new Date("2026-02-21T09:00:00"))
+   ```
+   - Expected: selected experiment changes when date changes (for list length > 1).
+5. Edge-case quick check in browser console or temporary snippet:
+   ```ts
+   getDeterministicExperimentByDate([]) // null
+   getDeterministicExperimentByDate([experiments[0]]) // experiments[0]
+   ```

--- a/lib/todays-experiment.ts
+++ b/lib/todays-experiment.ts
@@ -1,0 +1,39 @@
+import type { Experiment } from "../experiments";
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+function hashString(input: string): number {
+  let hash = 0;
+  for (let i = 0; i < input.length; i += 1) {
+    hash = (hash * 31 + input.charCodeAt(i)) >>> 0;
+  }
+  return hash;
+}
+
+function toLocalDateKey(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function toLocalEpochDay(date: Date): number {
+  const midnightLocal = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+  return Math.floor(midnightLocal.getTime() / MS_PER_DAY);
+}
+
+export function getDeterministicExperimentByDate(
+  list: Experiment[],
+  date: Date = new Date()
+): Experiment | null {
+  if (list.length === 0) return null;
+  if (list.length === 1) return list[0];
+
+  const dateKey = toLocalDateKey(date);
+  const slugSeed = list.map((experiment) => experiment.slug).join("|");
+  const offset = hashString(`${dateKey}|${slugSeed}`) % list.length;
+  const dayIndex = toLocalEpochDay(date) % list.length;
+  const index = (dayIndex + offset) % list.length;
+
+  return list[index];
+}


### PR DESCRIPTION
## Summary
- add `getDeterministicExperimentByDate` helper seeded by local `YYYY-MM-DD` + slug list
- use helper on home page for today's experiment selection
- handle edge cases for empty/single experiment list
- harden random pick helper when there is no alternative experiment
- add smoke verification doc for issue #127

## Verification
- `pnpm lint`
- `docs/verification/issue-127-deterministic-today-experiment.md`

Closes #127
