### PR TITLE
docs: reconcile next-actions/ideation after #125 closure and #127 merge

### DIFF
--- a/docs/ideation/INDEX.md
+++ b/docs/ideation/INDEX.md
@@ -11,26 +11,26 @@
 
 ## Recently Completed Cards
 
+- [#127](https://github.com/higgs-jung/tf-prd-lab/issues/127) — deterministic "today's experiment" section resolution → merged via [PR #128](https://github.com/higgs-jung/tf-prd-lab/pull/128)
+- [#125](https://github.com/higgs-jung/tf-prd-lab/issues/125) — ideation INDEX + next-actions refresh after recent merges → merged via [PR #126](https://github.com/higgs-jung/tf-prd-lab/pull/126)
 - [#123](https://github.com/higgs-jung/tf-prd-lab/issues/123) — docs reconcile (`docs/next-actions.md` + `docs/STATUS.md`) → merged via [PR #124](https://github.com/higgs-jung/tf-prd-lab/pull/124)
-- [#115](https://github.com/higgs-jung/tf-prd-lab/issues/115) — backlog hygiene (`docs/next-actions.md` status/link cleanup) → merged via [PR #116](https://github.com/higgs-jung/tf-prd-lab/pull/116)
 
 ## Next 1–2 Actions (Pick One)
 
-### 1) Close current docs sync loop (#125)
-- Why now: 현재 오픈 이슈가 #125 1건이며, 문서 포인터 최신화가 완료되면 backlog 탐색 지연을 줄일 수 있음.
-- Scope: `docs/next-actions.md`, `docs/ideation/INDEX.md`, run 1개, `.state.json` 동기화.
-- Done: 이슈 #125 머지 완료 + 문서 간 포인터 불일치 0.
-- Tracking issue: [#125](https://github.com/higgs-jung/tf-prd-lab/issues/125)
-
-### 2) Next product-facing ticket 1건 발행
-- Why now: 문서 정리 이슈가 거의 마무리 단계라, 다음 구현 사이클 진입을 위한 실행 단위 확보가 필요함.
+### 1) Open next product-facing implementation issue (Small)
+- Why now: 현재 오픈 Issue/PR가 없어 다음 실행 사이클 진입을 위한 작업 단위가 필요함.
 - Scope: `docs/PRD.md`/`docs/PRODUCT_PRD.md` 기준으로 Small 사이즈 이슈 1건 정의.
 - Done: Assignee/DoD가 명확한 새 이슈 1건 생성.
+
+### 2) Keep docs pointers warm after first new issue lands
+- Why now: 새 이슈 생성 직후 `next-actions`/`INDEX` 정합성을 유지하면 탐색 비용을 줄일 수 있음.
+- Scope: 이슈 번호/상태/링크를 `docs/next-actions.md`와 본 문서에 즉시 반영.
+- Done: 문서 간 상태 불일치 0 유지.
 
 ## Runs
 
 - Active run template: [runs/TEMPLATE.md](./runs/TEMPLATE.md)
-- Latest run: [runs/ideation-20260218-1951.md](./runs/ideation-20260218-1951.md)
+- Latest run: [runs/ideation-20260219-0458.md](./runs/ideation-20260219-0458.md)
 - Archive index: [_archive/README.md](./_archive/README.md)
 - Latest archived run: [_archive/ideation-20260214-0412.md](./_archive/ideation-20260214-0412.md)
 

--- a/docs/ideation/runs/ideation-20260219-0458.md
+++ b/docs/ideation/runs/ideation-20260219-0458.md
@@ -1,0 +1,19 @@
+# Ideation Run — 2026-02-19 04:58 (Asia/Seoul)
+
+## Context
+- Trigger: docs sync after [Issue #127](https://github.com/higgs-jung/tf-prd-lab/issues/127) / [PR #128](https://github.com/higgs-jung/tf-prd-lab/pull/128) merge and [Issue #125](https://github.com/higgs-jung/tf-prd-lab/issues/125) close.
+- Goal: `next-actions`와 ideation INDEX를 현재 저장소 상태(오픈 Issue/PR 없음)와 정합화.
+
+## Changes
+- `docs/next-actions.md`
+  - Ticket #125 상태를 `DONE`으로 이관
+  - Ticket #127 완료 항목 추가 (PR #128 링크 포함)
+  - Active 섹션을 "오픈 작업 없음"으로 정리
+- `docs/ideation/INDEX.md`
+  - Recently Completed Cards에 #127 추가
+  - Next 1–2 Actions를 "다음 신규 이슈 발행" 기준으로 갱신
+  - Latest run 포인터를 본 문서로 갱신
+
+## Outcome
+- 문서 기준 현재 상태: 오픈 Issue 0, 오픈 PR 0.
+- 본 변경은 docs-only 범위로 유지.

--- a/docs/next-actions.md
+++ b/docs/next-actions.md
@@ -1,6 +1,6 @@
 # Next Actions
 
-_Last updated: 2026-02-18 19:51 (Asia/Seoul)_
+_Last updated: 2026-02-19 04:58 (Asia/Seoul)_
 
 상태 라벨 표준: `DONE` | `IN_PROGRESS` | `BLOCKED`
 
@@ -11,19 +11,19 @@ _Last updated: 2026-02-18 19:51 (Asia/Seoul)_
 
 ## Active (IN_PROGRESS / BLOCKED)
 
-### Ticket 125 — ideation INDEX + next-actions refresh after recent merges
-- **Status:** IN_PROGRESS
-- **Priority:** P0
-- **Estimated:** Small (10–20m)
-- **Issue:** <https://github.com/higgs-jung/tf-prd-lab/issues/125>
-- **PR:** (to be created)
-- **DoD:**
-  - [ ] `docs/next-actions.md`에서 Ticket 123을 DONE으로 정리
-  - [ ] `docs/ideation/INDEX.md` Next 1–2 Actions 및 Latest run 포인터 갱신
-  - [ ] `docs/ideation/runs/` run 1개 추가 + `.state.json` cooldown 갱신
-  - [ ] Judge PASS 후 머지
+- 현재 오픈 작업 없음.
 
 ## Completed (DONE)
+
+### Ticket 127 — deterministic "today's experiment" section resolution
+- **Status:** DONE
+- **Issue:** <https://github.com/higgs-jung/tf-prd-lab/issues/127> (closed)
+- **Implementation PR:** <https://github.com/higgs-jung/tf-prd-lab/pull/128> (merged)
+
+### Ticket 125 — ideation INDEX + next-actions refresh after recent merges
+- **Status:** DONE
+- **Issue:** <https://github.com/higgs-jung/tf-prd-lab/issues/125> (closed)
+- **Implementation PR:** <https://github.com/higgs-jung/tf-prd-lab/pull/126> (merged)
 
 ### Ticket 123 — Docs: reconcile docs/next-actions.md + STATUS with actual repo state
 - **Status:** DONE
@@ -58,5 +58,5 @@ _Last updated: 2026-02-18 19:51 (Asia/Seoul)_
 - **Implementation PR:** <https://github.com/higgs-jung/tf-prd-lab/pull/9> (merged)
 
 ## Notes
-- 현재 저장소의 오픈 작업은 Issue #125 1건이며, 오픈 PR은 없음. (작성 시점 기준)
-- Ticket 123은 PR #124 머지로 종료되었고, 본 문서에서 DONE으로 이관함.
+- 현재 저장소의 오픈 Issue/PR 없음. (작성 시점 기준)
+- Ticket 125(#126), Ticket 127(#128) 모두 머지 완료되어 DONE으로 이관함.


### PR DESCRIPTION
## Summary
- move Ticket #125 from IN_PROGRESS to DONE in `docs/next-actions.md`
- add completion entry for Issue #127 with merged PR #128
- update `docs/ideation/INDEX.md` recently completed + next actions for current no-open-work state
- add a short ideation run note for this docs sync

## Verification
- `pnpm -s lint` (PASS)

## References
- Issue #127: https://github.com/higgs-jung/tf-prd-lab/issues/127
- PR #128: https://github.com/higgs-jung/tf-prd-lab/pull/128
- Issue #125: https://github.com/higgs-jung/tf-prd-lab/issues/125
