### PR TITLE
feat: add /changelog MVP page

### DIFF
--- a/app/changelog/page.tsx
+++ b/app/changelog/page.tsx
@@ -1,0 +1,115 @@
+import Link from "next/link";
+
+const mergedPrs = [
+  {
+    number: 131,
+    title: "feat: add concise About page for Geek Lab",
+    mergedAt: "2026-02-19",
+    url: "https://github.com/higgs-jung/tf-prd-lab/pull/131",
+  },
+  {
+    number: 129,
+    title: "docs: reconcile next-actions/ideation after #125 closure and #127 merge",
+    mergedAt: "2026-02-19",
+    url: "https://github.com/higgs-jung/tf-prd-lab/pull/129",
+  },
+  {
+    number: 128,
+    title: "feat: deterministic 오늘의 실험 selection (date-seeded)",
+    mergedAt: "2026-02-19",
+    url: "https://github.com/higgs-jung/tf-prd-lab/pull/128",
+  },
+  {
+    number: 126,
+    title: "docs: refresh next-actions + ideation index after #123 merge (#125)",
+    mergedAt: "2026-02-18",
+    url: "https://github.com/higgs-jung/tf-prd-lab/pull/126",
+  },
+  {
+    number: 124,
+    title: "docs: reconcile next-actions/STATUS with actual GitHub state (#123)",
+    mergedAt: "2026-02-18",
+    url: "https://github.com/higgs-jung/tf-prd-lab/pull/124",
+  },
+];
+
+const operatingNotes = [
+  "Ship small PRs and merge frequently.",
+  "Keep experiments isolated and easy to roll back.",
+  "Prioritize clear docs so contributors can move fast.",
+  "Prefer deterministic behavior in user-facing daily picks.",
+];
+
+const usefulLinks = [
+  { label: "Repository", href: "https://github.com/higgs-jung/tf-prd-lab" },
+  { label: "Open Issues", href: "https://github.com/higgs-jung/tf-prd-lab/issues" },
+  { label: "Open Pull Requests", href: "https://github.com/higgs-jung/tf-prd-lab/pulls" },
+  { label: "Project README", href: "https://github.com/higgs-jung/tf-prd-lab/blob/main/README.md" },
+];
+
+export default function ChangelogPage() {
+  return (
+    <main className="min-h-screen p-8">
+      <div className="mx-auto max-w-4xl space-y-10">
+        <header>
+          <h1 className="mb-3 text-4xl font-bold">Changelog</h1>
+          <p className="text-lg text-gray-600 dark:text-gray-400">
+            Lightweight project updates: recent merged pull requests, operating notes, and quick links.
+          </p>
+        </header>
+
+        <section>
+          <h2 className="mb-4 text-2xl font-semibold">Recent merged pull requests</h2>
+          <ul className="space-y-3">
+            {mergedPrs.map((pr) => (
+              <li key={pr.number} className="rounded-lg border border-gray-200 p-4 dark:border-gray-700">
+                <a
+                  href={pr.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="font-medium text-blue-600 hover:underline dark:text-blue-400"
+                >
+                  #{pr.number} · {pr.title}
+                </a>
+                <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">Merged: {pr.mergedAt}</p>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="mb-4 text-2xl font-semibold">Operating notes</h2>
+          <ul className="list-disc space-y-2 pl-6 text-gray-700 dark:text-gray-300">
+            {operatingNotes.map((note) => (
+              <li key={note}>{note}</li>
+            ))}
+          </ul>
+        </section>
+
+        <section>
+          <h2 className="mb-4 text-2xl font-semibold">Useful links</h2>
+          <ul className="space-y-2">
+            {usefulLinks.map((link) => (
+              <li key={link.href}>
+                <a
+                  href={link.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-blue-600 hover:underline dark:text-blue-400"
+                >
+                  {link.label}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <div>
+          <Link href="/" className="text-sm text-gray-600 underline underline-offset-2 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100">
+            ← Back to home
+          </Link>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -128,18 +128,24 @@ export default function Home() {
         </section>
 
         {/* Navigation */}
-        <nav className="flex gap-4 mb-8">
+        <nav className="mb-8 flex flex-wrap gap-4">
           <Link
             href="/experiments"
-            className="px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+            className="rounded-lg bg-blue-600 px-6 py-3 text-white transition-colors hover:bg-blue-700"
           >
             View All Experiments
           </Link>
           <Link
             href="/about"
-            className="px-6 py-3 bg-gray-200 dark:bg-gray-700 rounded-lg hover:bg-gray-300 dark:hover:bg-gray-600 transition-colors"
+            className="rounded-lg bg-gray-200 px-6 py-3 transition-colors hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600"
           >
             About
+          </Link>
+          <Link
+            href="/changelog"
+            className="rounded-lg bg-gray-200 px-6 py-3 transition-colors hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600"
+          >
+            Changelog
           </Link>
         </nav>
 
@@ -165,6 +171,7 @@ export default function Home() {
           <ul className="list-disc list-inside space-y-2 text-gray-700 dark:text-gray-300">
             <li>Try the <strong>오늘의 실험</strong> (Today&apos;s Experiment) above</li>
             <li>Browse all <Link href="/experiments" className="text-blue-600 dark:text-blue-400 hover:underline">Experiments</Link></li>
+            <li>Check recent updates in <Link href="/changelog" className="text-blue-600 dark:text-blue-400 hover:underline">Changelog</Link></li>
             <li>Learn more <Link href="/about" className="text-blue-600 dark:text-blue-400 hover:underline">About</Link> this project</li>
           </ul>
         </div>


### PR DESCRIPTION
## Summary
- add a new static `/changelog` page as MVP
- include recent merged PR links, operating notes, and useful links
- add navigation from home page to the changelog

## Testing
- pnpm lint

Closes #132