### PR TITLE
feat: improve /changelog readability structure + links (#140)

### DIFF
--- a/app/changelog/page.tsx
+++ b/app/changelog/page.tsx
@@ -1,9 +1,14 @@
 import Link from "next/link";
 
+type ChangelogLink = {
+  type: "PR" | "Issue";
+  number: number;
+};
+
 type ChangelogItem = {
   date: string;
   summary: string;
-  links: Array<{ label: string; href: string }>;
+  links?: ChangelogLink[];
 };
 
 const changelogItems: ChangelogItem[] = [
@@ -11,34 +16,50 @@ const changelogItems: ChangelogItem[] = [
     date: "2026-02-20",
     summary: "커스텀 404(not-found) 페이지를 추가해 잘못된 경로 접근 시 복귀 경로를 명확히 안내합니다.",
     links: [
-      { label: "PR #137", href: "https://github.com/higgs-jung/tf-prd-lab/pull/137" },
-      { label: "Issue #136", href: "https://github.com/higgs-jung/tf-prd-lab/issues/136" },
+      { type: "PR", number: 137 },
+      { type: "Issue", number: 136 },
     ],
   },
   {
     date: "2026-02-19",
     summary: "About 페이지를 간결하게 정리해 프로젝트 정체성과 운영 맥락을 빠르게 파악할 수 있게 개선했습니다.",
-    links: [{ label: "PR #131", href: "https://github.com/higgs-jung/tf-prd-lab/pull/131" }],
+    links: [{ type: "PR", number: 131 }],
   },
   {
     date: "2026-02-19",
     summary: "next-actions / ideation 문서를 실제 GitHub 상태와 맞추어 업데이트해 작업 추적 가독성을 높였습니다.",
-    links: [{ label: "PR #129", href: "https://github.com/higgs-jung/tf-prd-lab/pull/129" }],
+    links: [{ type: "PR", number: 129 }],
   },
   {
     date: "2026-02-19",
     summary: "오늘의 실험을 날짜 기반 seed로 결정해 하루 동안 일관된 실험 카드가 노출되도록 했습니다.",
-    links: [{ label: "PR #128", href: "https://github.com/higgs-jung/tf-prd-lab/pull/128" }],
+    links: [{ type: "PR", number: 128 }],
   },
   {
     date: "2026-02-18",
     summary: "문서 흐름(STATUS/next-actions)을 정리해 Planner→Captain→Worker 운영 루프와 최신 상태를 동기화했습니다.",
     links: [
-      { label: "PR #126", href: "https://github.com/higgs-jung/tf-prd-lab/pull/126" },
-      { label: "PR #124", href: "https://github.com/higgs-jung/tf-prd-lab/pull/124" },
+      { type: "PR", number: 126 },
+      { type: "PR", number: 124 },
     ],
   },
 ];
+
+function buildGithubLink(link: ChangelogLink) {
+  const base = "https://github.com/higgs-jung/tf-prd-lab";
+
+  if (link.type === "PR") {
+    return {
+      href: `${base}/pull/${link.number}`,
+      label: `PR #${link.number}`,
+    };
+  }
+
+  return {
+    href: `${base}/issues/${link.number}`,
+    label: `Issue #${link.number}`,
+  };
+}
 
 export default function ChangelogPage() {
   return (
@@ -48,33 +69,47 @@ export default function ChangelogPage() {
           <p className="text-xs font-semibold uppercase tracking-[0.18em] text-blue-600 dark:text-blue-300">Project updates</p>
           <h1 className="text-4xl font-bold">Changelog</h1>
           <p className="text-lg text-gray-600 dark:text-gray-400">
-            날짜 · 요약 · 링크 중심으로 최근 변경사항을 빠르게 스캔할 수 있도록 정리했습니다.
+            날짜 · 요약 · 관련 링크를 같은 카드 구조로 고정해 최근 변경사항을 빠르게 읽을 수 있게 정리했습니다.
           </p>
         </header>
 
-        <section className="space-y-4">
-          {changelogItems.map((item, index) => (
-            <article
-              key={`${item.date}-${index}`}
-              className="rounded-2xl border border-gray-200 bg-white/80 p-5 shadow-sm dark:border-gray-700 dark:bg-gray-800/40"
-            >
-              <p className="text-sm font-semibold text-gray-500 dark:text-gray-400">{item.date}</p>
-              <p className="mt-2 text-base leading-relaxed text-gray-800 dark:text-gray-100">{item.summary}</p>
-              <div className="mt-3 flex flex-wrap gap-2">
-                {item.links.map((link) => (
-                  <a
-                    key={link.href}
-                    href={link.href}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-900/30 dark:text-blue-300 dark:hover:bg-blue-900/50"
-                  >
-                    {link.label}
-                  </a>
-                ))}
-              </div>
-            </article>
-          ))}
+        <section aria-label="최근 변경 이력">
+          <ol className="space-y-4">
+            {changelogItems.map((item, index) => (
+              <li key={`${item.date}-${index}`}>
+                <article className="rounded-2xl border border-gray-200 bg-white/80 p-5 shadow-sm dark:border-gray-700 dark:bg-gray-800/40">
+                  <div className="flex flex-wrap items-center gap-2 text-sm">
+                    <span className="rounded-full bg-gray-100 px-2.5 py-1 font-semibold text-gray-600 dark:bg-gray-700 dark:text-gray-200">
+                      {item.date}
+                    </span>
+                    <span className="text-gray-500 dark:text-gray-400">업데이트</span>
+                  </div>
+
+                  <p className="mt-3 text-base leading-relaxed text-gray-800 dark:text-gray-100">{item.summary}</p>
+
+                  {item.links && item.links.length > 0 ? (
+                    <ul className="mt-3 flex flex-wrap gap-2" aria-label="관련 PR 및 이슈">
+                      {item.links.map((link) => {
+                        const githubLink = buildGithubLink(link);
+                        return (
+                          <li key={`${link.type}-${link.number}`}>
+                            <a
+                              href={githubLink.href}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-sm text-blue-700 transition hover:bg-blue-100 dark:border-blue-800 dark:bg-blue-900/30 dark:text-blue-300 dark:hover:bg-blue-900/50"
+                            >
+                              {githubLink.label}
+                            </a>
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  ) : null}
+                </article>
+              </li>
+            ))}
+          </ol>
         </section>
 
         <div>


### PR DESCRIPTION
## Summary
- Refined `/changelog` into a consistent list/card structure (`ol > li > article`) for easier scanning.
- Added explicit **date + title + short summary** for each entry.
- Added/kept relevant PR/Issue links where available, while staying fully static (no API/DB).

## Scope
- `app/changelog/page.tsx` only

## Manual verification
1. Run `pnpm dev` and open `/changelog`.
2. Confirm each item renders with date, title, summary, and link chips.
3. Confirm links open PR/Issue targets in new tab.
4. Confirm layout is consistent across entries (same card/list pattern).

## Validation
- `pnpm lint`
- `pnpm build`

Closes #140
