### PR TITLE
docs: reconcile next-actions/STATUS with current issue state (#149)

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,6 @@
 # Milestone Snapshot
 
-_Last updated: 2026-02-18 16:22 (Asia/Seoul)_
+_Last updated: 2026-02-22 11:16 (Asia/Seoul)_
 
 빠른 컨텍스트 진입용 문서입니다. 자세한 기준/백로그는 아래 문서를 우선 참조하세요.
 
@@ -25,12 +25,12 @@ _Last updated: 2026-02-18 16:22 (Asia/Seoul)_
 ## Milestone 2 — Deploy & Ops Reliability
 - **DONE:** Vercel Next.js 404 대응 PR(#8) 머지 완료.
 - **DONE:** repo healthcheck + CI 관련 최근 작업들 머지/close 완료.
-- **IN_PROGRESS:** 없음(문서 정합성 개선 작업은 Issue #123로 별도 추적).
+- **IN_PROGRESS:** 문서 정합성 업데이트 Issue #149 진행 중.
 - **BLOCKED:** 없음(문서 기준으로 확인 가능한 오픈 blocker 없음).
 - **RISKS:** CI/배포 이슈 재발 시 즉시 next-actions에 재등록 필요.
 
 ## 1-minute summary
 - 현재 오픈 PR은 없음.
-- 현재 오픈 Issue는 #123(문서 정합성 업데이트) 1건.
+- 현재 오픈 Issue는 #149(문서 정합성 업데이트) 1건.
 - milestone 관점의 기능/배포 blocker는 현재 기준으로 없음.
-- 이 PR 머지 후 문서 상태와 GitHub 실제 상태가 다시 일치함.
+- #149 머지 시 문서 상태와 GitHub 실제 상태가 다시 일치함.

--- a/docs/next-actions.md
+++ b/docs/next-actions.md
@@ -1,6 +1,6 @@
 # Next Actions
 
-_Last updated: 2026-02-19 04:58 (Asia/Seoul)_
+_Last updated: 2026-02-22 11:15 (Asia/Seoul)_
 
 상태 라벨 표준: `DONE` | `IN_PROGRESS` | `BLOCKED`
 
@@ -11,9 +11,16 @@ _Last updated: 2026-02-19 04:58 (Asia/Seoul)_
 
 ## Active (IN_PROGRESS / BLOCKED)
 
-- 현재 오픈 작업 없음.
+### Ticket 149 — docs: next-actions/STATUS 최신화 (오픈 티켓 0 반영)
+- **Status:** IN_PROGRESS
+- **Issue:** <https://github.com/higgs-jung/tf-prd-lab/issues/149>
 
 ## Completed (DONE)
+
+### Ticket 138 — /changelog 가독성 개선
+- **Status:** DONE
+- **Issue:** <https://github.com/higgs-jung/tf-prd-lab/issues/138> (closed)
+- **Implementation PR:** <https://github.com/higgs-jung/tf-prd-lab/pull/139> (merged)
 
 ### Ticket 127 — deterministic "today's experiment" section resolution
 - **Status:** DONE
@@ -58,5 +65,6 @@ _Last updated: 2026-02-19 04:58 (Asia/Seoul)_
 - **Implementation PR:** <https://github.com/higgs-jung/tf-prd-lab/pull/9> (merged)
 
 ## Notes
-- 현재 저장소의 오픈 Issue/PR 없음. (작성 시점 기준)
-- Ticket 125(#126), Ticket 127(#128) 모두 머지 완료되어 DONE으로 이관함.
+- 현재 오픈 Issue: #149 1건 (본 문서/STATUS 정합성 업데이트).
+- 현재 오픈 PR: 0건.
+- Ticket 138(#139)은 머지/이슈 closed 상태를 반영해 DONE으로 이관함.


### PR DESCRIPTION
## Summary
- update `docs/next-actions.md` active/completed sections to match current GitHub state
- move Ticket 138 to DONE with merged PR reference
- refresh open issue/PR notes (Issue #149 open, PR 0)
- minimally sync `docs/STATUS.md` snapshot/summary to Issue #149

## Scope
- docs only (`docs/next-actions.md`, `docs/STATUS.md`)

Closes #149
