### PR TITLE
docs: ideation INDEX Next Actions 정합성 복구

### DIFF
--- a/docs/ideation/INDEX.md
+++ b/docs/ideation/INDEX.md
@@ -11,26 +11,29 @@
 
 ## Recently Completed Cards
 
+- [#147](https://github.com/higgs-jung/tf-prd-lab/issues/147) — docs: /changelog에 '작성 가이드' 링크 추가 → merged via [PR #148](https://github.com/higgs-jung/tf-prd-lab/pull/148)
+- [#145](https://github.com/higgs-jung/tf-prd-lab/issues/145) — feat: 오늘의 실험 섹션에서 /changelog로 연결 (closed)
+- [#143](https://github.com/higgs-jung/tf-prd-lab/issues/143) — changelog 항목 작성 가이드 추가 → merged via [PR #144](https://github.com/higgs-jung/tf-prd-lab/pull/144)
 - [#127](https://github.com/higgs-jung/tf-prd-lab/issues/127) — deterministic "today's experiment" section resolution → merged via [PR #128](https://github.com/higgs-jung/tf-prd-lab/pull/128)
 - [#125](https://github.com/higgs-jung/tf-prd-lab/issues/125) — ideation INDEX + next-actions refresh after recent merges → merged via [PR #126](https://github.com/higgs-jung/tf-prd-lab/pull/126)
 - [#123](https://github.com/higgs-jung/tf-prd-lab/issues/123) — docs reconcile (`docs/next-actions.md` + `docs/STATUS.md`) → merged via [PR #124](https://github.com/higgs-jung/tf-prd-lab/pull/124)
 
 ## Next 1–2 Actions (Pick One)
 
-### 1) Open next product-facing implementation issue (Small)
-- Why now: 현재 오픈 Issue/PR가 없어 다음 실행 사이클 진입을 위한 작업 단위가 필요함.
-- Scope: `docs/PRD.md`/`docs/PRODUCT_PRD.md` 기준으로 Small 사이즈 이슈 1건 정의.
-- Done: Assignee/DoD가 명확한 새 이슈 1건 생성.
+### 1) Fix ideation INDEX stale Next Actions (Small)
+- Issue: [#153 docs: ideation INDEX Next Actions 정합성 복구 (stale 링크 제거)](https://github.com/higgs-jung/tf-prd-lab/issues/153)
+- Why now: idle일 때 이 문서가 단일 엔트리포인트인데, CLOSED 카드가 섞이면 다음 실행 선택이 깨짐.
+- Done: Next Actions에 CLOSED 이슈 링크 0 + Latest run 최신화
 
-### 2) Keep docs pointers warm after first new issue lands
-- Why now: 새 이슈 생성 직후 `next-actions`/`INDEX` 정합성을 유지하면 탐색 비용을 줄일 수 있음.
-- Scope: 이슈 번호/상태/링크를 `docs/next-actions.md`와 본 문서에 즉시 반영.
-- Done: 문서 간 상태 불일치 0 유지.
+### 2) Keep pointers warm
+- Why now: 작은 변경이 연속될 때 `docs/INDEX.md`/`docs/next-actions.md` 정합성 유지가 누적 비용을 줄임.
+- Scope: 링크/상태 표기만 최소 수정
+- Done: 문서 간 상태 불일치 0 유지
 
 ## Runs
 
 - Active run template: [runs/TEMPLATE.md](./runs/TEMPLATE.md)
-- Latest run: [runs/ideation-20260219-0458.md](./runs/ideation-20260219-0458.md)
+- Latest run: [runs/ideation-20260223-0507.md](./runs/ideation-20260223-0507.md)
 - Archive index: [_archive/README.md](./_archive/README.md)
 - Latest archived run: [_archive/ideation-20260214-0412.md](./_archive/ideation-20260214-0412.md)
 

--- a/docs/ideation/runs/ideation-20260223-0507.md
+++ b/docs/ideation/runs/ideation-20260223-0507.md
@@ -1,0 +1,42 @@
+# Ideation Run — 2026-02-23 05:07 (Asia/Seoul)
+
+Context: 현재 오픈 PR/이슈가 0개로 idle 상태. `docs/ideation/INDEX.md`의 Next Actions 섹션에 이미 CLOSED된 이슈(#151)가 남아 있어, 다음 실행 액션 선택이 혼란스러워짐.
+
+## Candidate Cards
+
+### Card A — docs: Ideation INDEX의 Next Actions 정합성 복구 (stale issue 제거)
+- Problem: ideation INDEX가 CLOSED된 이슈를 추천 카드로 유지하고 있어 “다음 1~2 액션”이 즉시 실행 가능하지 않음.
+- Proposal: `docs/ideation/INDEX.md`에서 CLOSED 카드(#151) 제거/이동하고, 현재 상태에 맞는 다음 액션 1개를 새로 제안.
+- Scope (files):
+  - `docs/ideation/INDEX.md`
+- Why now: idle일 때 이 문서가 사실상 단일 엔트리포인트라 정합성이 곧 효율.
+- Acceptance:
+  - Next Actions에 CLOSED 이슈 링크 0
+  - Latest run 링크가 최신 run을 가리킴
+
+### Card B — docs: 링크 유지보수 가이드(짧은 체크리스트) 추가
+- Problem: 문서 링크/상태가 자주 바뀌는데, 변경 후 점검 기준이 분산됨.
+- Proposal: `docs/ideation/INDEX.md` 또는 `docs/next-actions.md`에 “링크 점검 60초 체크리스트” 추가.
+- Scope (files):
+  - `docs/ideation/INDEX.md` 또는 `docs/next-actions.md`
+- Why now: 반복 작업을 규칙화하면 누적 비용 감소.
+- Acceptance:
+  - 체크리스트 5줄 이내
+  - 신규 기여자가 따라할 수 있는 수준
+
+## Recommendation (Pick One)
+
+- 선택 카드: Card A
+- 선택 이유(1~2문장): 이미 stale 상태가 발생했고, 지금 바로 복구하면 다음 사이클의 실행 선택 비용을 즉시 줄일 수 있음.
+
+## Promote to issue/backlog?
+
+- [x] Yes
+- [ ] No
+- Note: 작은 docs 이슈로 승격해서 작업/완료 흔적을 남기고 INDEX도 동시에 갱신.
+
+## Link updates checklist
+
+- [ ] `docs/ideation/INDEX.md`에 최신 상태 반영
+- [ ] 필요 시 `docs/INDEX.md` 링크 갱신
+- [ ] run 종료 시 문서를 `_archive/`로 이동 (삭제 금지)


### PR DESCRIPTION
## Summary
- remove stale Next Actions guidance and align to open Issue #153
- ensure Latest run points to `runs/ideation-20260223-0507.md`
- keep pointer-only, minimal-scope update in `docs/ideation/INDEX.md`

## Acceptance check
- [x] Next Actions contains 0 CLOSED issue links
- [x] Latest run link matches latest run document

Closes #153